### PR TITLE
GBX.NET 0.14.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ GBX.NET is a GameBox (.Gbx) file parser library written in C# for .NET software 
 
 \* Consider extracting `CGameCtnGhost` from `CGameCtnReplayRecord`, transfer it over to `CGameCtnMediaBlockGhost`, add it to `CGameCtnMediaClip`, and save it as `.Clip.Gbx`, which you can then import in MediaTracker.
 
+### For any questions, join [my Discord server](https://discord.gg/perAcdxscQ) or message me via DM: BigBang1112#9489
+
 ## Compatibility
 
 - GBX.NET is compatible down to **.NET Standard 2.0** and **.NET Framework 4.8**.

--- a/Src/GBX.NET/Byte3.cs
+++ b/Src/GBX.NET/Byte3.cs
@@ -23,10 +23,10 @@ public struct Byte3
     }
 
     /// <summary>
-    /// Converts the bytes to a string format of "({X}, {Y}, {Z})".
+    /// Converts the bytes to a string format of "&lt;{X}, {Y}, {Z}&gt;".
     /// </summary>
     /// <returns>Returns formatted <see cref="string"/>.</returns>
-    public override string ToString() => $"({X}, {Y}, {Z})";
+    public override string ToString() => $"<{X}, {Y}, {Z}>";
     public override int GetHashCode() => X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode();
     public override bool Equals(object? obj) => obj is Byte3 a && a == this;
 

--- a/Src/GBX.NET/Byte3.cs
+++ b/Src/GBX.NET/Byte3.cs
@@ -22,6 +22,13 @@ public struct Byte3
         Z = z;
     }
 
+    public void Deconstruct(out byte x, out byte y, out byte z)
+    {
+        x = X;
+        y = Y;
+        z = Z;
+    }
+
     /// <summary>
     /// Converts the bytes to a string format of "&lt;{X}, {Y}, {Z}&gt;".
     /// </summary>

--- a/Src/GBX.NET/Collection.cs
+++ b/Src/GBX.NET/Collection.cs
@@ -36,7 +36,7 @@ public struct Collection
 
     public Int3 GetBlockSize()
     {
-        return (ToString()) switch
+        return ToString() switch
         {
             "Desert" => (32, 16, 32),
             "Snow" => (32, 16, 32),

--- a/Src/GBX.NET/Engines/Game/CGameCtnMacroBlockInfo.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMacroBlockInfo.cs
@@ -87,8 +87,8 @@ public sealed class CGameCtnMacroBlockInfo : CGameCtnCollector
                 if ((flags & (1 << 26)) != 0)
                 {
                     block.IsFree = true;
-                    block.AbsolutePositionInMap = block.AbsolutePositionInMap.GetValueOrDefault() + position.GetValueOrDefault();
-                    block.PitchYawRoll += pitchYawRoll.GetValueOrDefault();
+                    //block.AbsolutePositionInMap = block.AbsolutePositionInMap.GetValueOrDefault() + position.GetValueOrDefault();
+                    //block.PitchYawRoll += pitchYawRoll.GetValueOrDefault();
                 }
 
                 return block;

--- a/Src/GBX.NET/Engines/MwFoundations/CMwNod.cs
+++ b/Src/GBX.NET/Engines/MwFoundations/CMwNod.cs
@@ -431,10 +431,12 @@ public class CMwNod
             {
                 if (chunk is ISkippableChunk s && !s.Discovered)
                     s.Write(msW);
-                else if (!Attribute.IsDefined(chunk.GetType(), typeof(AutoReadWriteChunkAttribute)))
+                else if (!IsIgnorableChunk(chunk))
                     ((IChunk)chunk).ReadWrite(this, rw);
+                else if (chunk is ISkippableChunk sIgnored)
+                    msW.WriteBytes(sIgnored.Data);
                 else
-                    msW.Write(chunk.Unknown.ToArray(), 0, (int)chunk.Unknown.Length);
+                    msW.WriteBytes(chunk.Unknown.ToArray());
 
                 w.Write(Chunk.Remap(chunk.ID, remap));
 
@@ -465,6 +467,14 @@ public class CMwNod
             Log.Write(logNodeCompletion, ConsoleColor.Green);
         else
             Log.Write($"~ {logNodeCompletion}", ConsoleColor.Green);
+    }
+
+    private static bool IsIgnorableChunk(Chunk chunk)
+    {
+        var chunkType = chunk.GetType();
+
+        return Attribute.IsDefined(chunkType, typeof(AutoReadWriteChunkAttribute))
+            || Attribute.IsDefined(chunkType, typeof(IgnoreChunkAttribute));
     }
 
     public T? GetChunk<T>() where T : Chunk

--- a/Src/GBX.NET/GameBoxReader.cs
+++ b/Src/GBX.NET/GameBoxReader.cs
@@ -246,6 +246,19 @@ public class GameBoxReader : BinaryReader
 
         var index = ReadUInt32();
 
+        if (index == uint.MaxValue)
+        {
+            return new Id("", lookbackable);
+        }
+
+        if ((index >> 16 & 0x1FF) == 0x1FF) // ????
+        {
+            var bytes = ReadBytes(5);
+            var length = bytes[2];
+            var str = ReadString(length);
+            return new Id(str, lookbackable);
+        }
+
         if ((index & 0x3FFF) == 0 && (index >> 30 == 1 || index >> 30 == 2))
         {
             var str = ReadString();

--- a/Src/GBX.NET/GameBoxReaderWriter.cs
+++ b/Src/GBX.NET/GameBoxReaderWriter.cs
@@ -17,6 +17,8 @@ public class GameBoxReaderWriter
     /// </summary>
     public GameBoxWriter? Writer { get; }
 
+    public Stream BaseStream => Reader?.BaseStream ?? Writer?.BaseStream ?? throw new ThisShouldNotHappenException();
+
     /// <summary>
     /// Mode of the reader-writer.
     /// </summary>

--- a/Src/GBX.NET/Ident.cs
+++ b/Src/GBX.NET/Ident.cs
@@ -26,6 +26,13 @@ public class Ident
 
     }
 
+    public void Deconstruct(out string id, out Collection collection, out string author)
+    {
+        id = ID;
+        collection = Collection;
+        author = Author;
+    }
+
     public override string ToString() => $"(\"{ID}\", \"{Collection}\", \"{Author}\")";
     public override int GetHashCode() => ID.GetHashCode() ^ Collection.GetHashCode() ^ Author.GetHashCode();
     public override bool Equals(object? obj) => this is Ident m && this == m;

--- a/Src/GBX.NET/Int2.cs
+++ b/Src/GBX.NET/Int2.cs
@@ -11,7 +11,7 @@ public struct Int2
         Y = y;
     }
 
-    public override string ToString() => $"({X}, {Y})";
+    public override string ToString() => $"<{X}, {Y}>";
     public override int GetHashCode() => X.GetHashCode() ^ Y.GetHashCode();
     public override bool Equals(object? obj) => obj is Int2 a && a == this;
 

--- a/Src/GBX.NET/Int2.cs
+++ b/Src/GBX.NET/Int2.cs
@@ -11,6 +11,12 @@ public struct Int2
         Y = y;
     }
 
+    public void Deconstruct(out int x, out int y)
+    {
+        x = X;
+        y = Y;
+    }
+
     public override string ToString() => $"<{X}, {Y}>";
     public override int GetHashCode() => X.GetHashCode() ^ Y.GetHashCode();
     public override bool Equals(object? obj) => obj is Int2 a && a == this;

--- a/Src/GBX.NET/Int3.cs
+++ b/Src/GBX.NET/Int3.cs
@@ -20,7 +20,7 @@ public struct Int3
         Z = z;
     }
 
-    public override string ToString() => $"({X}, {Y}, {Z})";
+    public override string ToString() => $"<{X}, {Y}, {Z}>";
     public override int GetHashCode() => X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode();
     public override bool Equals(object? obj) => obj is Int3 a && a == this;
 

--- a/Src/GBX.NET/Int3.cs
+++ b/Src/GBX.NET/Int3.cs
@@ -20,6 +20,13 @@ public struct Int3
         Z = z;
     }
 
+    public void Deconstruct(out int x, out int y, out int z)
+    {
+        x = X;
+        y = Y;
+        z = Z;
+    }
+
     public override string ToString() => $"<{X}, {Y}, {Z}>";
     public override int GetHashCode() => X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode();
     public override bool Equals(object? obj) => obj is Int3 a && a == this;

--- a/Src/GBX.NET/Quaternion.cs
+++ b/Src/GBX.NET/Quaternion.cs
@@ -20,6 +20,14 @@ public struct Quaternion
 
     }
 
+    public void Deconstruct(out float x, out float y, out float z, out float w)
+    {
+        x = X;
+        y = Y;
+        z = Z;
+        w = W;
+    }
+
     public Vec3 ToPitchYawRoll()
     {
         var pitch = (float)Math.Atan2(2 * X * W - 2 * Y * Z, 1 - 2 * X * X - 2 * Z * Z);

--- a/Src/GBX.NET/SkippableChunk.cs
+++ b/Src/GBX.NET/SkippableChunk.cs
@@ -45,6 +45,13 @@ public class SkippableChunk<T> : Chunk<T>, ISkippableChunk where T : CMwNod
         if (Discovered) return;
         Discovered = true;
 
+        if (NodeCacheManager.AvailableChunkAttributesByType.TryGetValue(GetType(), out IEnumerable<Attribute>? chunkAttributes))
+        {
+            var ignoreChunkAttribute = chunkAttributes.FirstOrDefault(x => x is IgnoreChunkAttribute);
+            if (ignoreChunkAttribute is not null)
+                return;
+        }
+
         using var ms = new MemoryStream(Data);
         using var gbxr = CreateReader(ms);
         var gbxrw = new GameBoxReaderWriter(gbxr);
@@ -55,7 +62,7 @@ public class SkippableChunk<T> : Chunk<T>, ISkippableChunk where T : CMwNod
         }
         catch (NotImplementedException)
         {
-            var unknownGbxw = CreateWriter(Unknown);
+            using var unknownGbxw = CreateWriter(Unknown);
 
             try
             {

--- a/Src/GBX.NET/Vec2.cs
+++ b/Src/GBX.NET/Vec2.cs
@@ -13,6 +13,12 @@ public struct Vec2 : IVec
         Y = y;
     }
 
+    public void Deconstruct(out float x, out float y)
+    {
+        x = X;
+        y = Y;
+    }
+
     public float GetMagnitude() => (float)Math.Sqrt(X * X + Y * Y);
     public float GetSqrMagnitude() => X * X + Y * Y;
 

--- a/Src/GBX.NET/Vec2.cs
+++ b/Src/GBX.NET/Vec2.cs
@@ -1,4 +1,6 @@
-﻿namespace GBX.NET;
+﻿using System.Globalization;
+
+namespace GBX.NET;
 
 public struct Vec2 : IVec
 {
@@ -14,7 +16,14 @@ public struct Vec2 : IVec
     public float GetMagnitude() => (float)Math.Sqrt(X * X + Y * Y);
     public float GetSqrMagnitude() => X * X + Y * Y;
 
-    public override string ToString() => $"({X}, {Y})";
+    public override string ToString()
+    {
+        var x = X.ToString(CultureInfo.InvariantCulture);
+        var y = Y.ToString(CultureInfo.InvariantCulture);
+
+        return $"<{x}, {y}>";
+    } 
+
     public override int GetHashCode() => X.GetHashCode() ^ Y.GetHashCode();
     public override bool Equals(object? obj) => obj is Vec2 a && a == this;
 

--- a/Src/GBX.NET/Vec3.cs
+++ b/Src/GBX.NET/Vec3.cs
@@ -21,6 +21,13 @@ public struct Vec3 : IVec
         Z = z;
     }
 
+    public void Deconstruct(out float x, out float y, out float z)
+    {
+        x = X;
+        y = Y;
+        z = Z;
+    }
+
     public float GetMagnitude() => (float)Math.Sqrt(X * X + Y * Y + Z * Z);
     public float GetSqrMagnitude() => X * X + Y * Y + Z * Z;
 

--- a/Src/GBX.NET/Vec3.cs
+++ b/Src/GBX.NET/Vec3.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.Serialization;
 
 namespace GBX.NET;
@@ -23,7 +24,15 @@ public struct Vec3 : IVec
     public float GetMagnitude() => (float)Math.Sqrt(X * X + Y * Y + Z * Z);
     public float GetSqrMagnitude() => X * X + Y * Y + Z * Z;
 
-    public override string ToString() => $"({X}, {Y}, {Z})";
+    public override string ToString()
+    {
+        var x = X.ToString(CultureInfo.InvariantCulture);
+        var y = Y.ToString(CultureInfo.InvariantCulture);
+        var z = Z.ToString(CultureInfo.InvariantCulture);
+
+        return $"<{x}, {y}, {z}>";
+    }
+
     public override int GetHashCode() => X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode();
     public override bool Equals(object? obj) => obj is Vec3 a && a == this;
 

--- a/Src/GBX.NET/Vec4.cs
+++ b/Src/GBX.NET/Vec4.cs
@@ -1,4 +1,6 @@
-﻿namespace GBX.NET;
+﻿using System.Globalization;
+
+namespace GBX.NET;
 
 public struct Vec4 : IVec
 {
@@ -15,7 +17,16 @@ public struct Vec4 : IVec
         W = w;
     }
 
-    public override string ToString() => $"({X}, {Y}, {Z}, {W})";
+    public override string ToString()
+    {
+        var x = X.ToString(CultureInfo.InvariantCulture);
+        var y = Y.ToString(CultureInfo.InvariantCulture);
+        var z = Z.ToString(CultureInfo.InvariantCulture);
+        var w = W.ToString(CultureInfo.InvariantCulture);
+
+        return $"<{x}, {y}, {z}, {w}>";
+    }
+
     public override int GetHashCode() => X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode() ^ W.GetHashCode();
     public override bool Equals(object? obj) => obj is Vec4 a && a == this;
 

--- a/Src/GBX.NET/Vec4.cs
+++ b/Src/GBX.NET/Vec4.cs
@@ -17,6 +17,14 @@ public struct Vec4 : IVec
         W = w;
     }
 
+    public void Deconstruct(out float x, out float y, out float z, out float w)
+    {
+        x = X;
+        y = Y;
+        z = Z;
+        w = W;
+    }
+
     public override string ToString()
     {
         var x = X.ToString(CultureInfo.InvariantCulture);


### PR DESCRIPTION
- Temporarily ignore data about free blocks (the project is not too far to figure these out finally)
- Removed `AbsolutePositionInMap` and `PitchYawRoll` from `CGameCtnBlock`
- Removed `PlaceFreeBlock()` from `CGameCtnChallenge`
- Made IsFree unsettable
- Byte3/Int2/Int3/Vec2/Vec3/Vec4's `ToString()` is formatted into `<x, y, z>` instead of `(x, y, z)`
- `Discover()` method wont work on ignored chunk
- Added weird `Id` parsing methods
- Added deconstructors to Byte3, Int2, Int3, Vec2, Vec3, Vec4, Quaternion and Ident