### PR TITLE
Fix ObjFileExporter vertex indices between layers

### DIFF
--- a/Src/GBX.NET/Utils/ObjFileExporter.cs
+++ b/Src/GBX.NET/Utils/ObjFileExporter.cs
@@ -107,7 +107,11 @@ internal class ObjFileExporter : IModelExporter, IDisposable
 
         var writtenVerts = new HashSet<Vec3>();
         var writtenUVs = new HashSet<Vec2>();
-        
+
+        var positionsDict = mergeVerticesDigitThreshold.HasValue
+            ? new Dictionary<Vec3, int>(new Comparers.Vec3EqualityComparer(mergeVerticesDigitThreshold.Value))
+            : new Dictionary<Vec3, int>();
+
         foreach (var layer in crystal.Layers)
         {
             objFaceWriter.WriteLine("\no {0}", layer.LayerName);
@@ -118,10 +122,6 @@ internal class ObjFileExporter : IModelExporter, IDisposable
             }
 
             var positions = geometryLayer.Crystal.Positions;
-
-            var positionsDict = mergeVerticesDigitThreshold.HasValue
-                ? new Dictionary<Vec3, int>(positions.Length, new Comparers.Vec3EqualityComparer(mergeVerticesDigitThreshold.Value))
-                : new Dictionary<Vec3, int>(positions.Length);
 
             for (int i = 0; i < positions.Length; i++)
             {


### PR DESCRIPTION
The `positionsDict` Dictionary keeping track of vertex indices was being reset for each layer. This caused all layers after the first layer to point to vertices starting at vertex 1, while the vertices are actually being written after the vertices of the first layer.

This PR solves this issue by moving the `positionsDict` to before the `Layers` iteration to ensure all vertex indices (based on position) are shared between layers.