### PR TITLE
GBX.NET 0.16.5

### DIFF
--- a/GBX.NET.sln
+++ b/GBX.NET.sln
@@ -76,7 +76,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{F438
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{40C97995-1F9C-4C12-8DD4-E542BA5AD0D0}"
 	ProjectSection(SolutionItems) = preProject
-		.github\workflows\dotnet-dev.yml = .github\workflows\dotnet-dev.yml
 		.github\workflows\dotnet.yml = .github\workflows\dotnet.yml
 		.github\workflows\publish-pre.yml = .github\workflows\publish-pre.yml
 		.github\workflows\publish.yml = .github\workflows\publish.yml
@@ -88,7 +87,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IconExporter", "Samples\Ico
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RefTableTree", "Samples\RefTableTree\RefTableTree.csproj", "{EE18E6A2-9DE9-4117-A5F5-55DDB8F4EBE0}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GBX.NET.Tests.Generators", "Tests\GBX.NET.Tests.Generators\GBX.NET.Tests.Generators.csproj", "{2C2E289A-3727-40CA-8255-A27B2AC60013}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Generators", "Generators", "{CE7346E4-9386-4CBF-B10E-354637911774}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GBX.NET.Generators", "Generators\GBX.NET.Generators\GBX.NET.Generators.csproj", "{D9AEC2A9-6BC6-441A-AFEE-DE549FCCCF44}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GeneratorBase", "Generators\GeneratorBase\GeneratorBase.csproj", "{EE8168B3-BD18-4D3B-BA6F-50CED55245DA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GBX.NET.Tests.Generators", "Generators\GBX.NET.Tests.Generators\GBX.NET.Tests.Generators.csproj", "{63A83F16-04A0-4DB0-A689-4A8263479FB9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -388,18 +393,42 @@ Global
 		{EE18E6A2-9DE9-4117-A5F5-55DDB8F4EBE0}.Release|x64.Build.0 = Release|Any CPU
 		{EE18E6A2-9DE9-4117-A5F5-55DDB8F4EBE0}.Release|x86.ActiveCfg = Release|Any CPU
 		{EE18E6A2-9DE9-4117-A5F5-55DDB8F4EBE0}.Release|x86.Build.0 = Release|Any CPU
-		{2C2E289A-3727-40CA-8255-A27B2AC60013}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2C2E289A-3727-40CA-8255-A27B2AC60013}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2C2E289A-3727-40CA-8255-A27B2AC60013}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{2C2E289A-3727-40CA-8255-A27B2AC60013}.Debug|x64.Build.0 = Debug|Any CPU
-		{2C2E289A-3727-40CA-8255-A27B2AC60013}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{2C2E289A-3727-40CA-8255-A27B2AC60013}.Debug|x86.Build.0 = Debug|Any CPU
-		{2C2E289A-3727-40CA-8255-A27B2AC60013}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2C2E289A-3727-40CA-8255-A27B2AC60013}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2C2E289A-3727-40CA-8255-A27B2AC60013}.Release|x64.ActiveCfg = Release|Any CPU
-		{2C2E289A-3727-40CA-8255-A27B2AC60013}.Release|x64.Build.0 = Release|Any CPU
-		{2C2E289A-3727-40CA-8255-A27B2AC60013}.Release|x86.ActiveCfg = Release|Any CPU
-		{2C2E289A-3727-40CA-8255-A27B2AC60013}.Release|x86.Build.0 = Release|Any CPU
+		{D9AEC2A9-6BC6-441A-AFEE-DE549FCCCF44}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9AEC2A9-6BC6-441A-AFEE-DE549FCCCF44}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9AEC2A9-6BC6-441A-AFEE-DE549FCCCF44}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D9AEC2A9-6BC6-441A-AFEE-DE549FCCCF44}.Debug|x64.Build.0 = Debug|Any CPU
+		{D9AEC2A9-6BC6-441A-AFEE-DE549FCCCF44}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D9AEC2A9-6BC6-441A-AFEE-DE549FCCCF44}.Debug|x86.Build.0 = Debug|Any CPU
+		{D9AEC2A9-6BC6-441A-AFEE-DE549FCCCF44}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9AEC2A9-6BC6-441A-AFEE-DE549FCCCF44}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9AEC2A9-6BC6-441A-AFEE-DE549FCCCF44}.Release|x64.ActiveCfg = Release|Any CPU
+		{D9AEC2A9-6BC6-441A-AFEE-DE549FCCCF44}.Release|x64.Build.0 = Release|Any CPU
+		{D9AEC2A9-6BC6-441A-AFEE-DE549FCCCF44}.Release|x86.ActiveCfg = Release|Any CPU
+		{D9AEC2A9-6BC6-441A-AFEE-DE549FCCCF44}.Release|x86.Build.0 = Release|Any CPU
+		{EE8168B3-BD18-4D3B-BA6F-50CED55245DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE8168B3-BD18-4D3B-BA6F-50CED55245DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE8168B3-BD18-4D3B-BA6F-50CED55245DA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EE8168B3-BD18-4D3B-BA6F-50CED55245DA}.Debug|x64.Build.0 = Debug|Any CPU
+		{EE8168B3-BD18-4D3B-BA6F-50CED55245DA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EE8168B3-BD18-4D3B-BA6F-50CED55245DA}.Debug|x86.Build.0 = Debug|Any CPU
+		{EE8168B3-BD18-4D3B-BA6F-50CED55245DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE8168B3-BD18-4D3B-BA6F-50CED55245DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE8168B3-BD18-4D3B-BA6F-50CED55245DA}.Release|x64.ActiveCfg = Release|Any CPU
+		{EE8168B3-BD18-4D3B-BA6F-50CED55245DA}.Release|x64.Build.0 = Release|Any CPU
+		{EE8168B3-BD18-4D3B-BA6F-50CED55245DA}.Release|x86.ActiveCfg = Release|Any CPU
+		{EE8168B3-BD18-4D3B-BA6F-50CED55245DA}.Release|x86.Build.0 = Release|Any CPU
+		{63A83F16-04A0-4DB0-A689-4A8263479FB9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63A83F16-04A0-4DB0-A689-4A8263479FB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63A83F16-04A0-4DB0-A689-4A8263479FB9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{63A83F16-04A0-4DB0-A689-4A8263479FB9}.Debug|x64.Build.0 = Debug|Any CPU
+		{63A83F16-04A0-4DB0-A689-4A8263479FB9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{63A83F16-04A0-4DB0-A689-4A8263479FB9}.Debug|x86.Build.0 = Debug|Any CPU
+		{63A83F16-04A0-4DB0-A689-4A8263479FB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63A83F16-04A0-4DB0-A689-4A8263479FB9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63A83F16-04A0-4DB0-A689-4A8263479FB9}.Release|x64.ActiveCfg = Release|Any CPU
+		{63A83F16-04A0-4DB0-A689-4A8263479FB9}.Release|x64.Build.0 = Release|Any CPU
+		{63A83F16-04A0-4DB0-A689-4A8263479FB9}.Release|x86.ActiveCfg = Release|Any CPU
+		{63A83F16-04A0-4DB0-A689-4A8263479FB9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -430,7 +459,9 @@ Global
 		{FE607A3A-FDFC-4FF5-88A5-DD65043B5F5D} = {1870006D-F5DC-4711-98DD-5502B74B848E}
 		{DE982586-835F-4B8D-8EDE-A0066256CB4F} = {C2F85CC4-B870-4C4D-B681-2E268F8C7F54}
 		{EE18E6A2-9DE9-4117-A5F5-55DDB8F4EBE0} = {C2F85CC4-B870-4C4D-B681-2E268F8C7F54}
-		{2C2E289A-3727-40CA-8255-A27B2AC60013} = {3489EC85-665E-43FC-9D25-A939E498EE1A}
+		{D9AEC2A9-6BC6-441A-AFEE-DE549FCCCF44} = {CE7346E4-9386-4CBF-B10E-354637911774}
+		{EE8168B3-BD18-4D3B-BA6F-50CED55245DA} = {CE7346E4-9386-4CBF-B10E-354637911774}
+		{63A83F16-04A0-4DB0-A689-4A8263479FB9} = {CE7346E4-9386-4CBF-B10E-354637911774}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1345F8B9-81BD-4394-B810-43D109A5A33A}

--- a/Generators/GBX.NET.Generators/AsHeaderGenerator.cs
+++ b/Generators/GBX.NET.Generators/AsHeaderGenerator.cs
@@ -8,6 +8,8 @@ namespace GBX.NET.Generators;
 [Generator]
 public class AsHeaderGenerator : ISourceGenerator
 {
+    private const string ConstIHeader = "IHeader";
+
     public void Initialize(GeneratorInitializationContext context)
     {
 #if DEBUG
@@ -21,7 +23,29 @@ public class AsHeaderGenerator : ISourceGenerator
     public void Execute(GeneratorExecutionContext context)
     {
         // GBX.NET assembly
-        var enginesNamespace = context.Compilation.GlobalNamespace.NavigateToNamespace("GBX.NET.Engines") ?? throw new Exception("GBX.NET.Engines namespace not found.");
-        var engineTypes = enginesNamespace.GetNamespaceMembers().SelectMany(x => x.GetTypeMembers());
+        var enginesNamespace = context.Compilation
+            .GlobalNamespace
+            .NavigateToNamespace("GBX.NET.Engines") ?? throw new Exception("GBX.NET.Engines namespace not found.");
+
+        var engineTypesWithHeader = enginesNamespace.GetNamespaceMembers()
+            .SelectMany(x => x.GetTypeMembers())
+            .Where(x => x.Interfaces.Any(x => x.Name == ConstIHeader));
+
+        foreach (var type in engineTypesWithHeader)
+        {
+            context.AddSource($"{type.Name}.g.cs", @$"namespace GBX.NET.Engines.{type.ContainingNamespace.Name};
+
+public partial class {type.Name}
+{{
+    /// <summary>
+    /// Gets the node casted to an interface that shows values used in the header.
+    /// </summary>
+    /// <returns>An <see cref=""IHeader""/> of the node.</returns>
+    public {(type.BaseType?.Interfaces.Any(x => x.Name == ConstIHeader) == true ? "new " : "")}IHeader AsHeader()
+    {{
+        return this;
+    }}
+}}");
+        }
     }
 }

--- a/Generators/GBX.NET.Generators/AsHeaderGenerator.cs
+++ b/Generators/GBX.NET.Generators/AsHeaderGenerator.cs
@@ -1,0 +1,27 @@
+﻿using GBX.NET.Generators.Extensions;
+using Microsoft.CodeAnalysis;
+using System;
+using System.Diagnostics;
+
+namespace GBX.NET.Generators;
+
+[Generator]
+public class AsHeaderGenerator : ISourceGenerator
+{
+    public void Initialize(GeneratorInitializationContext context)
+    {
+#if DEBUG
+        if (!Debugger.IsAttached)
+        {
+            //Debugger.Launch();
+        }
+#endif
+    }
+
+    public void Execute(GeneratorExecutionContext context)
+    {
+        // GBX.NET assembly
+        var enginesNamespace = context.Compilation.GlobalNamespace.NavigateToNamespace("GBX.NET.Engines") ?? throw new Exception("GBX.NET.Engines namespace not found.");
+        var engineTypes = enginesNamespace.GetNamespaceMembers().SelectMany(x => x.GetTypeMembers());
+    }
+}

--- a/Generators/GBX.NET.Generators/Extensions/NamespaceSymbolExtensions.cs
+++ b/Generators/GBX.NET.Generators/Extensions/NamespaceSymbolExtensions.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace GBX.NET.Generators.Extensions;
+
+public static class NamespaceSymbolExtensions
+{
+    public static INamespaceSymbol? NavigateToNamespace(this INamespaceSymbol namespaceSymbol, string namespacePath)
+    {
+        var parts = namespacePath.Split('.');
+
+        foreach (var part in parts)
+        {
+            namespaceSymbol = namespaceSymbol.GetNamespaceMembers().FirstOrDefault(x => x.Name == part);
+
+            if (namespaceSymbol is null)
+            {
+                return null;
+            }
+        }
+
+        return namespaceSymbol;
+    }
+}

--- a/Generators/GBX.NET.Generators/GBX.NET.Generators.csproj
+++ b/Generators/GBX.NET.Generators/GBX.NET.Generators.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<IncludeBuildOutput>false</IncludeBuildOutput>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<LangVersion>10</LangVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" PrivateAssets="all" />
+	</ItemGroup>
+
+</Project>

--- a/Generators/GBX.NET.Tests.Generators/Extensions/NamespaceSymbolExtensions.cs
+++ b/Generators/GBX.NET.Tests.Generators/Extensions/NamespaceSymbolExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace GBX.NET.Tests.Generators.Extensions;
 
-internal static class NamespaceSymbolExtensions
+public static class NamespaceSymbolExtensions
 {
     public static INamespaceSymbol? NavigateToNamespace(this INamespaceSymbol namespaceSymbol, string namespacePath)
     {
@@ -17,7 +17,7 @@ internal static class NamespaceSymbolExtensions
                 return null;
             }
         }
-        
+
         return namespaceSymbol;
     }
 }

--- a/Generators/GBX.NET.Tests.Generators/GBX.NET.Tests.Generators.csproj
+++ b/Generators/GBX.NET.Tests.Generators/GBX.NET.Tests.Generators.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
@@ -13,8 +13,5 @@
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" PrivateAssets="all" />
 	</ItemGroup>
-
-	<ItemGroup>
-		<None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-	</ItemGroup>
+	
 </Project>

--- a/Generators/GBX.NET.Tests.Generators/ReadWriteEqualityTestGenerator.cs
+++ b/Generators/GBX.NET.Tests.Generators/ReadWriteEqualityTestGenerator.cs
@@ -2,8 +2,8 @@
 using Microsoft.CodeAnalysis.Text;
 using System.Diagnostics;
 using System.Text;
-using GBX.NET.Tests.Generators.Extensions;
 using System.IO.Compression;
+using GBX.NET.Tests.Generators.Extensions;
 
 namespace GBX.NET.Tests.Generators;
 

--- a/Generators/GeneratorBase/GeneratorBase.csproj
+++ b/Generators/GeneratorBase/GeneratorBase.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<LangVersion>10</LangVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" PrivateAssets="all" />
+	</ItemGroup>
+
+</Project>

--- a/README.md
+++ b/README.md
@@ -74,57 +74,57 @@ The library also speeds up parse time by ignoring unused skippable chunks with *
 Maps were selected from all kinds of Trackmania official campaigns picked by the biggest file size.
 
 ```
-BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1826 (21H1/May2021Update)
+BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1889 (21H1/May2021Update)
 AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
-.NET SDK=6.0.302
-  [Host]     : .NET 6.0.7 (6.0.722.32202), X64 RyuJIT  [AttachedDebugger]
-  Job-GUIHKJ : .NET 6.0.7 (6.0.722.32202), X64 RyuJIT
+.NET SDK=7.0.100-preview.6.22352.1
+  [Host]     : .NET 6.0.8 (6.0.822.36306), X64 RyuJIT  [AttachedDebugger]
+  Job-LTRNAC : .NET 6.0.8 (6.0.822.36306), X64 RyuJIT
 ```
 
 | File name | Read | Read header | Write
 | --- | --- | --- | ---
-| 0_TrackMania\1.2.5 DemoSolo\DemoRaceB1 | 0,20 ms | 0,02 ms | 0,24 ms
-| 4_TrackMania United\2\snowC5 | 0,26 ms | 0,04 ms | 0,33 ms
-| 1_TrackMania Sunrise\1.4.7\CleanLanding | 0,29 ms | 0,03 ms | 0,32 ms
-| 2_TrackMania Original\1.5 Demo\DemoRace3 | 0,30 ms | 0,04 ms | 0,28 ms
-| 0_TrackMania\1.2.3\RaceF7 | 0,31 ms | 0,03 ms | 0,34 ms
-| 4_TrackMania United\2.0.8\DesertE | 0,37 ms | 0,04 ms | 0,44 ms
-| 8_Trackmania 2020\Training\Training - 20 | 0,41 ms | 0,06 ms | 1,39 ms
-| 8_Trackmania 2020\Training\cR­ç»f - 20 | 0,41 ms | 0,05 ms | 1,31 ms
-| 1_TrackMania Sunrise\1.4.5\AirControl | 0,43 ms | 0,03 ms | 0,58 ms
-| 3_TrackMania Nations ESWC\1.7.5\Pro A-4 | 0,57 ms | 0,05 ms | 1,18 ms
-| 1_TrackMania Sunrise\1.4.5 Nvidia\TrialTime | 0,65 ms | 0,03 ms | 0,89 ms
-| 1_TrackMania Sunrise\1.5\TrialTime | 0,74 ms | 0,03 ms | 0,98 ms
-| 6_TrackMania 2\MP4\BaseValley | 0,75 ms | 0,04 ms | 1,61 ms
-| 1_TrackMania Sunrise\1.4.6\LittleWalk | 0,76 ms | 0,03 ms | 1,29 ms
-| 1_TrackMania Sunrise\1.5 Demo\DemoRace1 | 0,78 ms | 0,05 ms | 1,73 ms
-| 7_TrackMania Turbo\VR\VR_Stadium_007 | 0,88 ms | 0,05 ms | 2,27 ms
-| 6_TrackMania 2\MP4Valley\D13 | 1,01 ms | 0,04 ms | 2,38 ms
-| 5_TrackMania Forever\2.11.11 Nations\E02-Endurance | 1,19 ms | 0,03 ms | 2,16 ms
-| 6_TrackMania 2\MP4Lagoon\B01 | 1,22 ms | 0,03 ms | 2,55 ms
-| 6_TrackMania 2\MP3Platform\E03 - Ultimate Nightmare | 1,41 ms | 0,03 ms | 2,98 ms
-| 7_TrackMania Turbo\Solo\100 | 1,41 ms | 0,04 ms | 3,24 ms
-| 1_TrackMania Sunrise\1.4\Paradise Island | 1,43 ms | 0,03 ms | 5,35 ms
-| 6_TrackMania 2\MP3Valley\E01 | 1,46 ms | 0,04 ms | 3,30 ms
-| 6_TrackMania 2\MP3Stadium\E02 | 1,55 ms | 0,04 ms | 3,99 ms
-| 5_TrackMania Forever\2.11.11 United\StuntC1 | 1,72 ms | 0,03 ms | 4,79 ms
-| 8_Trackmania 2020\Royal\NoTechLogic | 1,80 ms | 0,11 ms | 5,07 ms
-| 5_TrackMania Forever\2.11.25\StarStadiumE | 1,86 ms | 0,03 ms | 2,42 ms
-| 0_TrackMania\1 Beta\Track6 | 1,97 ms | 0,02 ms | 9,86 ms
-| 2_TrackMania Original\1.5\StuntsD1 | 2,01 ms | 0,03 ms | 8,57 ms
-| 0_TrackMania\1 Demo\Track6 | 2,10 ms | 0,02 ms | 9,48 ms
-| 0_TrackMania\1.1\RaceD1 | 2,17 ms | 0,02 ms | 10,46 ms
-| 0_TrackMania\1\PuzzleF2 | 2,44 ms | 0,04 ms | 16,60 ms
-| 6_TrackMania 2\MP3Canyon\B10 | 2,46 ms | 0,03 ms | 2,98 ms
-| 8_Trackmania 2020\20200701\Summer 2020 - 11 | 2,52 ms | 0,05 ms | 6,59 ms
-| 8_Trackmania 2020\20210401\Spring 2021 - 23 | 2,70 ms | 0,05 ms | 7,34 ms
-| 8_Trackmania 2020\20200701\夏季赛 2020 - 11 | 2,72 ms | 0,05 ms | 6,41 ms
-| 8_Trackmania 2020\20201001\Fall 2020 - 12 | 2,75 ms | 0,05 ms | 6,65 ms
-| 8_Trackmania 2020\20201001\秋季 2020 - 12 | 2,77 ms | 0,04 ms | 6,59 ms
-| Community\CCP#04 - ODYSSEY | 2,95 ms | 0,04 ms | 7,01 ms
-| 8_Trackmania 2020\20210101\Winter 2021 - 15 | 3,42 ms | 0,06 ms | 8,76 ms
-| 8_Trackmania 2020\20210701\Summer 2021 - 25 | 4,17 ms | 0,06 ms | 10,08 ms
-| 8_Trackmania 2020\20211001\Fall 2021 - 16 | 12,35 ms | 0,10 ms | 15,92 ms
+| 0_TrackMania\1.2.5 DemoSolo\DemoRaceB1 | 0,23 ms | 0,04 ms | 0,26 ms
+| 4_TrackMania United\2\snowC5 | 0,30 ms | 0,05 ms | 0,34 ms
+| 2_TrackMania Original\1.5 Demo\DemoRace3 | 0,33 ms | 0,05 ms | 0,29 ms
+| 1_TrackMania Sunrise\1.4.7\CleanLanding | 0,33 ms | 0,04 ms | 0,34 ms
+| 0_TrackMania\1.2.3\RaceF7 | 0,39 ms | 0,05 ms | 0,37 ms
+| 4_TrackMania United\2.0.8\DesertE | 0,43 ms | 0,06 ms | 0,43 ms
+| 1_TrackMania Sunrise\1.4.5\AirControl | 0,50 ms | 0,04 ms | 0,67 ms
+| 3_TrackMania Nations ESWC\1.7.5\Pro A-4 | 0,64 ms | 0,05 ms | 1,34 ms
+| 1_TrackMania Sunrise\1.4.5 Nvidia\TrialTime | 0,68 ms | 0,04 ms | 1,03 ms
+| 1_TrackMania Sunrise\1.5\TrialTime | 0,76 ms | 0,05 ms | 1,01 ms
+| 1_TrackMania Sunrise\1.4.6\LittleWalk | 0,80 ms | 0,04 ms | 1,38 ms
+| 1_TrackMania Sunrise\1.5 Demo\DemoRace1 | 0,88 ms | 0,04 ms | 1,92 ms
+| 8_Trackmania 2020\Training\cR­ç»f - 20 | 0,95 ms | 0,05 ms | 2,17 ms
+| 8_Trackmania 2020\Training\Training - 20 | 0,99 ms | 0,07 ms | 1,96 ms
+| 6_TrackMania 2\MP4\BaseValley | 1,10 ms | 0,04 ms | 2,07 ms
+| 5_TrackMania Forever\2.11.11 Nations\E02-Endurance | 1,28 ms | 0,04 ms | 2,74 ms
+| 7_TrackMania Turbo\VR\VR_Stadium_007 | 1,29 ms | 0,06 ms | 2,79 ms
+| 1_TrackMania Sunrise\1.4\Paradise Island | 1,33 ms | 0,04 ms | 4,43 ms
+| 6_TrackMania 2\MP4Valley\D13 | 1,51 ms | 0,06 ms | 3,00 ms
+| 6_TrackMania 2\MP4Lagoon\B01 | 1,63 ms | 0,06 ms | 3,02 ms
+| 6_TrackMania 2\MP3Platform\E03 - Ultimate Nightmare | 1,68 ms | 0,04 ms | 3,04 ms
+| 5_TrackMania Forever\2.11.11 United\StuntC1 | 1,76 ms | 0,03 ms | 6,35 ms
+| 5_TrackMania Forever\2.11.25\StarStadiumE | 1,81 ms | 0,04 ms | 2,42 ms
+| 7_TrackMania Turbo\Solo\100 | 1,82 ms | 0,05 ms | 3,69 ms
+| 6_TrackMania 2\MP3Valley\E01 | 1,85 ms | 0,08 ms | 3,86 ms
+| 0_TrackMania\1.1\RaceD1 | 1,94 ms | 0,04 ms | 10,93 ms
+| 0_TrackMania\1 Demo\Track6 | 1,98 ms | 0,03 ms | 10,21 ms
+| 6_TrackMania 2\MP3Stadium\E02 | 1,99 ms | 0,06 ms | 4,48 ms
+| 2_TrackMania Original\1.5\StuntsD1 | 2,14 ms | 0,04 ms | 8,96 ms
+| 0_TrackMania\1 Beta\Track6 | 2,23 ms | 0,05 ms | 10,60 ms
+| 0_TrackMania\1\PuzzleF2 | 2,28 ms | 0,05 ms | 17,25 ms
+| 6_TrackMania 2\MP3Canyon\B10 | 2,92 ms | 0,03 ms | 3,24 ms
+| 8_Trackmania 2020\Royal\NoTechLogic | 2,92 ms | 0,12 ms | 6,96 ms
+| Community\CCP#04 - ODYSSEY | 3,31 ms | 0,05 ms | 8,62 ms
+| 8_Trackmania 2020\20201001\秋季 2020 - 12 | 3,55 ms | 0,05 ms | 9,08 ms
+| 8_Trackmania 2020\20201001\Fall 2020 - 12 | 3,56 ms | 0,06 ms | 8,96 ms
+| 8_Trackmania 2020\20210401\Spring 2021 - 23 | 3,56 ms | 0,06 ms | 9,39 ms
+| 8_Trackmania 2020\20200701\Summer 2020 - 11 | 3,62 ms | 0,07 ms | 8,98 ms
+| 8_Trackmania 2020\20200701\夏季赛 2020 - 11 | 3,81 ms | 0,08 ms | 9,31 ms
+| 8_Trackmania 2020\20210101\Winter 2021 - 15 | 4,48 ms | 0,06 ms | 12,76 ms
+| 8_Trackmania 2020\20210701\Summer 2021 - 25 | 6,01 ms | 0,05 ms | 15,53 ms
+| 8_Trackmania 2020\20211001\Fall 2021 - 16 | 13,46 ms | 0,12 ms | 19,10 ms
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ var silverTime = map.SilverTime; // Correct
 
 ## License
 
-- **The sub-library GBX.NET.LZO is licensed with [GNU General Public License v3.0](GBX.NET.LZO/LICENSE.GPL-3.0-or-later.md). If you're going to use this library, please license your work under GPL-3.0-or-later.**
+- **The sub-library GBX.NET.LZO is licensed with [GNU General Public License v3.0](Src/GBX.NET.LZO/LICENSE.GPL-3.0-or-later.md). If you're going to use this library, please license your work under GPL-3.0-or-later.**
 - **Everything in the Samples folder is also licensed with [GNU General Public License v3.0](Samples/LICENSE.GPL-3.0-or-later.md).**
 - The libraries GBX.NET, GBX.NET.Imaging, GBX.NET.Json, GBX.NET.Localization and the project DocGenerator **are licensed with MIT** and you can use them much more permissively.
 - Information gathered from the project (chunk structure, parse examples, data structure, wiki information, markdown) is usable with [The Unlicense](https://unlicense.org/).

--- a/Src/GBX.NET/Attributes/WebpDataAttribute.cs
+++ b/Src/GBX.NET/Attributes/WebpDataAttribute.cs
@@ -1,0 +1,6 @@
+﻿namespace GBX.NET.Attributes;
+
+[AttributeUsage(AttributeTargets.Property)]
+public class WebpDataAttribute : Attribute
+{
+}

--- a/Src/GBX.NET/Engines/Control/CControlBase.cs
+++ b/Src/GBX.NET/Engines/Control/CControlBase.cs
@@ -14,9 +14,11 @@ public abstract class CControlBase : CSceneToy
     #region Properties
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0700100C))]
     public string? StackText { get => stackText; set => stackText = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0700100E))]
     public CControlLayout? Layout { get => layout; set => layout = value; }
 
     #endregion

--- a/Src/GBX.NET/Engines/Control/CControlContainer.cs
+++ b/Src/GBX.NET/Engines/Control/CControlContainer.cs
@@ -14,9 +14,11 @@ public class CControlContainer : CControlBase
     #region Properties
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk07002005))]
     public bool AcceptOwnControls { get => acceptOwnControls; set => acceptOwnControls = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk07002005))]
     public bool UseScript { get => useScript; set => useScript = value; }
 
     #endregion

--- a/Src/GBX.NET/Engines/Control/CControlEffectSimi.cs
+++ b/Src/GBX.NET/Engines/Control/CControlEffectSimi.cs
@@ -32,24 +32,35 @@ public partial class CControlEffectSimi : CControlEffect, CGameCtnMediaBlock.IHa
     /// Keyframes of the effect.
     /// </summary>
     [NodeMember]
+    [AppliedWithChunk(typeof(Chunk07010002))]
+    [AppliedWithChunk(typeof(Chunk07010004))]
+    [AppliedWithChunk(typeof(Chunk07010005))]
     public IList<Key> Keys { get => keys; set => keys = value; }
 
     /// <summary>
     /// If the effect should be centered.
     /// </summary>
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk07010002))]
+    [AppliedWithChunk(typeof(Chunk07010004))]
+    [AppliedWithChunk(typeof(Chunk07010005))]
     public bool Centered { get => centered; set => centered = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk07010004))]
+    [AppliedWithChunk(typeof(Chunk07010005))]
     public int ColorBlendMode { get => colorBlendMode; set => colorBlendMode = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk07010004))]
+    [AppliedWithChunk(typeof(Chunk07010005))]
     public bool IsContinousEffect { get => isContinousEffect; set => isContinousEffect = value; }
 
     /// <summary>
     /// If the keyframes should interpolate values between each other.
     /// </summary>
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk07010005))]
     public bool IsInterpolated { get => isInterpolated; set => isInterpolated = value; }
 
     #endregion

--- a/Src/GBX.NET/Engines/Function/CFuncPlug.cs
+++ b/Src/GBX.NET/Engines/Function/CFuncPlug.cs
@@ -17,18 +17,30 @@ public abstract class CFuncPlug : CFunc
     #region Properties
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0500B003))]
+    [AppliedWithChunk(typeof(Chunk0500B004))]
+    [AppliedWithChunk(typeof(Chunk0500B005))]
     public float Period { get => period; set => period = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0500B003))]
+    [AppliedWithChunk(typeof(Chunk0500B004))]
+    [AppliedWithChunk(typeof(Chunk0500B005))]
     public float Phase { get => phase; set => phase = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0500B003))]
+    [AppliedWithChunk(typeof(Chunk0500B004))]
+    [AppliedWithChunk(typeof(Chunk0500B005))]
     public bool AutoCreateMotion { get => autoCreateMotion; set => autoCreateMotion = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0500B004))]
+    [AppliedWithChunk(typeof(Chunk0500B005))]
     public bool RandomizePhase { get => randomizePhase; set => randomizePhase = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0500B005))]
     public string? InputValId { get => inputValId; set => inputValId = value; }
 
     #endregion

--- a/Src/GBX.NET/Engines/Function/CFuncShaderLayerUV.cs
+++ b/Src/GBX.NET/Engines/Function/CFuncShaderLayerUV.cs
@@ -14,6 +14,7 @@ public class CFuncShaderLayerUV : CFuncShader
     #region Properties
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk05015005))]
     public string? LayerName { get => layerName; set => layerName = value; }
 
     #endregion

--- a/Src/GBX.NET/Engines/Function/CFuncTreeSubVisualSequence.cs
+++ b/Src/GBX.NET/Engines/Function/CFuncTreeSubVisualSequence.cs
@@ -1,4 +1,6 @@
-﻿namespace GBX.NET.Engines.Function;
+﻿using static GBX.NET.Engines.Function.CFuncShaderLayerUV;
+
+namespace GBX.NET.Engines.Function;
 
 /// <remarks>ID: 0x05031000</remarks>
 [Node(0x05031000)]
@@ -16,15 +18,20 @@ public class CFuncTreeSubVisualSequence : CFuncTree
     #region Properties
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk05031000))]
+    [AppliedWithChunk(typeof(Chunk05031002))]
     public CFuncKeysNatural? SubKeys { get => subKeys; set => subKeys = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk05031003))]
     public bool SimpleModeIsLooping { get => simpleModeIsLooping; set => simpleModeIsLooping = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk05031003))]
     public int SimpleModeStartIndex { get => simpleModeStartIndex; set => simpleModeStartIndex = value; }
     
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk05031003))]
     public int SimpleModeEndIndex { get => simpleModeEndIndex; set => simpleModeEndIndex = value; }
 
     #endregion
@@ -101,7 +108,7 @@ public class CFuncTreeSubVisualSequence : CFuncTree
 
     #endregion
 
-    #region 0x003
+    #region 0x003 chunk
 
     /// <summary>
     /// CFuncTreeSubVisualSequence 0x003 chunk

--- a/Src/GBX.NET/Engines/Game/CGameCampaignPlayerScores.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCampaignPlayerScores.cs
@@ -3,6 +3,7 @@
 [Node(0x030EA000)]
 public class CGameCampaignPlayerScores : CMwNod
 {
+    [NodeMember]
     public string? CampaignId { get; private set; }
 
     protected CGameCampaignPlayerScores()

--- a/Src/GBX.NET/Engines/Game/CGameCtnAnchoredObject.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnAnchoredObject.cs
@@ -29,57 +29,53 @@ public class CGameCtnAnchoredObject : CMwNod, INodeDependant<CGameCtnChallenge>
     /// Name of the item with collection and author
     /// </summary>
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03101002))]
     public Ident ItemModel { get => itemModel; set => itemModel = value; }
 
     /// <summary>
     /// Pitch, yaw and roll of the item in radians.
     /// </summary>
     [NodeMember]
+    [AppliedWithChunk(typeof(Chunk03101002))]
     public Vec3 PitchYawRoll { get => pitchYawRoll; set => pitchYawRoll = value; }
 
     /// <summary>
     /// Block coordinates that the item is approximately located in. It doesn't have to be provided most of the time.
     /// </summary>
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03101002))]
     public Byte3 BlockUnitCoord { get => blockUnitCoord; set => blockUnitCoord = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03101002))]
     public string AnchorTreeId { get => anchorTreeId; set => anchorTreeId = value; }
 
     /// <summary>
     /// The X, Y and Z position in the real world space of the item.
     /// </summary>
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03101002))]
     public Vec3 AbsolutePositionInMap { get => absolutePositionInMap; set => absolutePositionInMap = value; }
 
     /// <summary>
     /// If the item is a waypoint, contains inner waypoint info, otherwise null.
     /// </summary>
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03101002))]
     public CGameWaypointSpecialProperty? WaypointSpecialProperty { get => waypointSpecialProperty; set => waypointSpecialProperty = value; }
 
     /// <summary>
     /// Flags of the item.
     /// </summary>
     [NodeMember]
+    [AppliedWithChunk(typeof(Chunk03101002), sinceVersion: 4)]
     public short Flags { get => flags; set => flags = value; }
-
-    /// <summary>
-    /// Scale of the item. This value currently doesn't have any effect.
-    /// </summary>
-    [NodeMember(ExactlyNamed = true)]
-    public float Scale { get => scale; set => scale = value; }
-
-    /// <summary>
-    /// Pivot position of the item. Useful for making rotations around a different point than center.
-    /// </summary>
-    [NodeMember]
-    public Vec3 PivotPosition { get => pivotPosition; set => pivotPosition = value; }
 
     /// <summary>
     /// Variant index of the item. Taken from flags.
     /// </summary>
     [NodeMember]
+    [AppliedWithChunk(typeof(Chunk03101002), sinceVersion: 4)]
     public int Variant
     {
         get => (flags >> 8) & 15;
@@ -87,9 +83,24 @@ public class CGameCtnAnchoredObject : CMwNod, INodeDependant<CGameCtnChallenge>
     }
 
     /// <summary>
+    /// Pivot position of the item. Useful for making rotations around a different point than center.
+    /// </summary>
+    [NodeMember]
+    [AppliedWithChunk(typeof(Chunk03101002), sinceVersion: 5)]
+    public Vec3 PivotPosition { get => pivotPosition; set => pivotPosition = value; }
+
+    /// <summary>
+    /// Scale of the item. This value currently doesn't have any effect.
+    /// </summary>
+    [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03101002), sinceVersion: 6)]
+    public float Scale { get => scale; set => scale = value; }
+
+    /// <summary>
     /// Color of the item. Available since TM® Royal update.
     /// </summary>
     [NodeMember]
+    [AppliedWithChunk(typeof(Chunk03101002))]
     public DifficultyColor? Color
     {
         get
@@ -105,6 +116,7 @@ public class CGameCtnAnchoredObject : CMwNod, INodeDependant<CGameCtnChallenge>
     /// Skin used on the item.
     /// </summary>
     [NodeMember]
+    [AppliedWithChunk(typeof(Chunk03101002), sinceVersion: 7)]
     public FileRef? PackDesc { get => packDesc; set => packDesc = value; }
 
     CGameCtnChallenge? INodeDependant<CGameCtnChallenge>.DependingNode { get; set; }
@@ -115,7 +127,7 @@ public class CGameCtnAnchoredObject : CMwNod, INodeDependant<CGameCtnChallenge>
 
     protected CGameCtnAnchoredObject()
     {
-        itemModel = null!;
+        itemModel = Ident.Empty;
     }
 
     internal CGameCtnAnchoredObject(Ident itemModel, Vec3 absolutePositionInMap, Vec3 pitchYawRoll,

--- a/Src/GBX.NET/Engines/Game/CGameCtnAnchoredObject.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnAnchoredObject.cs
@@ -229,6 +229,11 @@ public class CGameCtnAnchoredObject : CMwNod, INodeDependant<CGameCtnChallenge>
                             {
                                 rw.Vec3(ref U01);
                                 rw.Vec3(ref U02);
+
+                                if (version >= 9)
+                                {
+                                    throw new VersionNotSupportedException(version);
+                                }
                             }
                         }
                     }

--- a/Src/GBX.NET/Engines/Game/CGameCtnBlock.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnBlock.cs
@@ -43,47 +43,36 @@ public class CGameCtnBlock : CMwNod, INodeDependant<CGameCtnChallenge>
         set
         {
             if (blockModel is null)
+            {
                 blockModel = new Ident(value);
-            else blockModel = new Ident(value, blockModel.Collection, blockModel.Author);
+            }
+            else
+            {
+                blockModel = new Ident(value, blockModel.Collection, blockModel.Author);
+            }
         }
     }
 
     [NodeMember]
-    public Ident BlockModel
-    {
-        get => blockModel;
-        set => blockModel = value;
-    }
+    public Ident BlockModel { get => blockModel; set => blockModel = value; }
 
     /// <summary>
     /// Facing direction of the block.
     /// </summary>
     [NodeMember]
-    public Direction Direction
-    {
-        get => direction;
-        set => direction = value;
-    }
+    public Direction Direction { get => direction; set => direction = value; }
 
     /// <summary>
     /// Position of the block on the map in block coordination. This value get's explicitly converted to <see cref="Byte3"/> in the serialized form. Values below 0 or above 255 should be avoided.
     /// </summary>
     [NodeMember]
-    public Int3 Coord
-    {
-        get => coord;
-        set => coord = value;
-    }
+    public Int3 Coord { get => coord; set => coord = value; }
 
     /// <summary>
     /// Flags of the block. If the chunk version is null, this value can be presented as <see cref="short"/>.
     /// </summary>
     [NodeMember]
-    public int Flags
-    {
-        get => flags;
-        set => flags = value;
-    }
+    public int Flags { get => flags; set => flags = value; }
 
     /// <summary>
     /// Author of the block, usually of a custom one made in Mesh Modeller.
@@ -255,7 +244,7 @@ public class CGameCtnBlock : CMwNod, INodeDependant<CGameCtnChallenge>
 
     protected CGameCtnBlock()
     {
-        blockModel = null!;
+        blockModel = Ident.Empty;
     }
 
     public CGameCtnBlock(Ident blockModel, Direction direction, Int3 coord, int flags)
@@ -317,7 +306,7 @@ public class CGameCtnBlock : CMwNod, INodeDependant<CGameCtnChallenge>
         {
             rw.Ident(ref n.blockModel!);
             rw.EnumByte<Direction>(ref n.direction);
-            n.coord = (Int3)rw.Byte3((Byte3)n.coord);
+            rw.Byte3(ref n.coord);
             rw.Int32(ref n.flags);
         }
     }

--- a/Src/GBX.NET/Engines/Game/CGameCtnBlockInfo.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnBlockInfo.cs
@@ -54,54 +54,73 @@ public abstract class CGameCtnBlockInfo : CGameCtnCollector
     private GameBoxRefTable.File? pillarFile;
 
     [NodeMember]
+    [AppliedWithChunk(typeof(Chunk0304E005))]
     public CGameCtnBlockUnitInfo?[]? GroundBlockUnitInfos { get => groundBlockUnitInfos; set => groundBlockUnitInfos = value; }
 
     [NodeMember]
+    [AppliedWithChunk(typeof(Chunk0304E005))]
     public CGameCtnBlockUnitInfo?[]? AirBlockUnitInfos { get => airBlockUnitInfos; set => airBlockUnitInfos = value; }
 
     [NodeMember]
+    [AppliedWithChunk(typeof(Chunk0304E005))]
     public ExternalNode<CSceneMobil>[][]? GroundMobils { get => groundMobils; set => groundMobils = value; }
 
     [NodeMember]
+    [AppliedWithChunk(typeof(Chunk0304E005))]
     public ExternalNode<CSceneMobil>[][]? AirMobils { get => airMobils; set => airMobils = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E009))]
+    [AppliedWithChunk(typeof(Chunk0304E02F))]
     public bool IsPillar { get => isPillar; set => isPillar = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E00E))]
+    [AppliedWithChunk(typeof(Chunk0304E026))]
     public EWayPointType? WayPointType { get => wayPointType; set => wayPointType = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E00F))]
     public bool NoRespawn { get => noRespawn; set => noRespawn = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E013))]
     public bool IconAutoUseGround { get => iconAutoUseGround; set => iconAutoUseGround = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E020))]
     public CPlugCharPhySpecialProperty? CharPhySpecialProperty { get => charPhySpecialProperty; set => charPhySpecialProperty = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E020), sinceVersion: 2)]
     public CGamePodiumInfo? PodiumInfo { get => podiumInfo; set => podiumInfo = value; }
     
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E020), sinceVersion: 3)]
     public CGamePodiumInfo? IntroInfo { get => introInfo; set => introInfo = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E020), sinceVersion: 4)]
     public bool CharPhySpecialPropertyCustomizable { get => charPhySpecialPropertyCustomizable; set => charPhySpecialPropertyCustomizable = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E027))]
     public CGameCtnBlockInfoVariantGround?[]? AdditionalVariantsGround { get => additionalVariantsGround; set => additionalVariantsGround = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E02C))]
     public CGameCtnBlockInfoVariantAir?[]? AdditionalVariantsAir { get => additionalVariantsAir; set => additionalVariantsAir = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E028))]
     public string? SymmetricalBlockInfoId { get => symmetricalBlockInfoId; set => symmetricalBlockInfoId = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E028))]
     public Direction? Dir { get => dir; set => dir = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E029))]
     public CPlugFogVolumeBox? FogVolumeBox
     {
         get => fogVolumeBox = GetNodeFromRefTable(fogVolumeBox, fogVolumeBoxFile) as CPlugFogVolumeBox;
@@ -109,6 +128,7 @@ public abstract class CGameCtnBlockInfo : CGameCtnCollector
     }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E02A))]
     public CPlugSound? Sound1
     {
         get => sound1 = GetNodeFromRefTable(sound1, sound1File) as CPlugSound;
@@ -116,6 +136,7 @@ public abstract class CGameCtnBlockInfo : CGameCtnCollector
     }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E02A))]
     public CPlugSound? Sound2
     {
         get => sound2 = GetNodeFromRefTable(sound2, sound2File) as CPlugSound;
@@ -123,21 +144,27 @@ public abstract class CGameCtnBlockInfo : CGameCtnCollector
     }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E02A))]
     public Iso4? Sound1Loc { get => sound1Loc; set => sound1Loc = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E02A))]
     public Iso4? Sound2Loc { get => sound2Loc; set => sound2Loc = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E02F))]
     public EMultiDir PillarShapeMultiDir { get => pillarShapeMultiDir; set => pillarShapeMultiDir = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E023))]
     public CGameCtnBlockInfoVariantGround? VariantBaseGround { get; set; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0304E023))]
     public CGameCtnBlockInfoVariantAir? VariantBaseAir { get; set; }
 
     [NodeMember]
+    [AppliedWithChunk(typeof(Chunk0304E005))]
     public CGameCtnBlockInfoClassic? Pillar
     {
         get => pillar = GetNodeFromRefTable(pillar, pillarFile) as CGameCtnBlockInfoClassic;
@@ -146,7 +173,7 @@ public abstract class CGameCtnBlockInfo : CGameCtnCollector
 
     protected CGameCtnBlockInfo()
     {
-        
+
     }
 
     [Chunk(0x0304E005)]

--- a/Src/GBX.NET/Engines/Game/CGameCtnBlockInfoClip.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnBlockInfoClip.cs
@@ -28,36 +28,47 @@ public class CGameCtnBlockInfoClip : CGameCtnBlockInfo
     private string? symmetricalClipGroupId;
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03053002))]
     public string? ASymmetricalClipId { get => aSymmetricalClipId; set => aSymmetricalClipId = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03053004))]
     public bool IsFullFreeClip { get => isFullFreeClip; set => isFullFreeClip = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03053004))]
     public bool IsExclusiveFreeClip { get => isExclusiveFreeClip; set => isExclusiveFreeClip = value; }
     
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03053005))]
     public EClipType ClipType { get => clipType; set => clipType = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03053006))]
     public bool CanBeDeletedByFullFreeClip { get => canBeDeletedByFullFreeClip; set => canBeDeletedByFullFreeClip = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03053006), sinceVersion: 1)]
     public EMultiDir TopBottomMultiDir { get => topBottomMultiDir; set => topBottomMultiDir = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03053007))]
     public bool HasPassingPoint { get => hasPassingPoint; set => hasPassingPoint = value; }
 
     [NodeMember]
+    [AppliedWithChunk(typeof(Chunk03053007))]
     public Vec2 PassingPointPos { get => passingPointPos; set => passingPointPos = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03053007))]
     public float PassingPointRoll { get => passingPointRoll; set => passingPointRoll = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03053007))]
     public float PassingPointPitch { get => passingPointPitch; set => passingPointPitch = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03053008))]
     public string? ClipGroupId
     {
         get
@@ -73,6 +84,7 @@ public class CGameCtnBlockInfoClip : CGameCtnBlockInfo
     }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03053008))]
     public string? SymmetricalClipGroupId
     {
         get

--- a/Src/GBX.NET/Engines/Game/CGameCtnBlockInfoMobil.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnBlockInfoMobil.cs
@@ -12,12 +12,11 @@ public class CGameCtnBlockInfoMobil : CMwNod
     private GameBoxRefTable.File? prefabFidFile;
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03122002))]
     public CGameCtnSolidDecals?[]? SolidDecals { get => solidDecals; set => solidDecals = value; }
 
     [NodeMember(ExactlyNamed = true)]
-    public CGameCtnBlockInfoMobilLink[]? DynaLinks { get => dynaLinks; set => dynaLinks = value; }
-
-    [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03122003), sinceVersion: 2)]
     public CPlugSolid? SolidFid
     {
         get => solidFid = GetNodeFromRefTable(solidFid, solidFidFile) as CPlugSolid;
@@ -25,11 +24,16 @@ public class CGameCtnBlockInfoMobil : CMwNod
     }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03122003), sinceVersion: 3)]
     public CPlugPrefab? PrefabFid
     {
         get => prefabFid = GetNodeFromRefTable(prefabFid, prefabFidFile) as CPlugPrefab;
         set => prefabFid = value;
     }
+
+    [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03122004))]
+    public CGameCtnBlockInfoMobilLink[]? DynaLinks { get => dynaLinks; set => dynaLinks = value; }
 
     protected CGameCtnBlockInfoMobil()
     {

--- a/Src/GBX.NET/Engines/Game/CGameCtnBlockInfoPylon.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnBlockInfoPylon.cs
@@ -28,15 +28,19 @@ public class CGameCtnBlockInfoPylon : CGameCtnBlockInfo
     }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03055002))]
     public float PylonOffset { get => pylonOffset; set => pylonOffset = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03055002))]
     public EPylonAmount PylonAmount { get => pylonAmount; set => pylonAmount = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03055002))]
     public EPylonPlacement PylonPlacement { get => pylonPlacement; set => pylonPlacement = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03055002))]
     public int BlockHeightOffset { get => blockHeightOffset; set => blockHeightOffset = value; }
 
     #region 0x000 chunk

--- a/Src/GBX.NET/Engines/Game/CGameCtnBlockInfoRoad.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnBlockInfoRoad.cs
@@ -12,6 +12,7 @@ public class CGameCtnBlockInfoRoad : CGameCtnBlockInfo
     private GameBoxRefTable.File? slopeFile;
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03052000))]
     public CGameCtnBlockInfoSlope? Slope
     {
         get => slope = GetNodeFromRefTable(slope, slopeFile) as CGameCtnBlockInfoSlope;

--- a/Src/GBX.NET/Engines/Game/CGameCtnBlockInfoVariant.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnBlockInfoVariant.cs
@@ -62,24 +62,31 @@ public abstract class CGameCtnBlockInfoVariant : CMwNod
     private Iso4 compoundLoc;
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B002))]
     public EMultiDir MultiDir { get => multiDir; set => multiDir = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B003))]
     public int SymmetricalVariantIndex { get => symmetricalVariantIndex; set => symmetricalVariantIndex = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B003))]
     public ECardinalDir CardinalDir { get => cardinalDir; set => cardinalDir = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B003), sinceVersion: 1)]
     public EVariantBaseType VariantBaseType { get => variantBaseType; set => variantBaseType = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B003), sinceVersion: 2)]
     public byte NoPillarBelowIndex { get => noPillarBelowIndex; set => noPillarBelowIndex = value; }
 
     [NodeMember]
+    [AppliedWithChunk(typeof(Chunk0315B005))]
     public CGameCtnBlockInfoMobil?[][]? Mobils { get => mobils; set => mobils = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B006))]
     public CMwNod? ScreenInteractionTriggerSolid
     {
         get => screenInteractionTriggerSolid = GetNodeFromRefTable(screenInteractionTriggerSolid, screenInteractionTriggerSolidFile) as CMwNod;
@@ -87,6 +94,7 @@ public abstract class CGameCtnBlockInfoVariant : CMwNod
     }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B006))]
     public CMwNod? WaypointTriggerSolid
     {
         get => waypointTriggerSolid = GetNodeFromRefTable(waypointTriggerSolid, waypointTriggerSolidFile) as CMwNod;
@@ -94,15 +102,19 @@ public abstract class CGameCtnBlockInfoVariant : CMwNod
     }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B006), sinceVersion: 2)]
     public CGameGateModel? Gate { get => gate; set => gate = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B006), sinceVersion: 3)]
     public CGameTeleporterModel? Teleporter { get => teleporter; set => teleporter = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B006), sinceVersion: 6)]
     public CGameTurbineModel? Turbine { get => turbine; set => turbine = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B006), sinceVersion: 7)]
     public CPlugFlockModel? FlockModel
     {
         get => flockModel = GetNodeFromRefTable(flockModel, flockModelFile) as CPlugFlockModel;
@@ -110,6 +122,7 @@ public abstract class CGameCtnBlockInfoVariant : CMwNod
     }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B006), sinceVersion: 8)]
     public CGameSpawnModel? SpawnModel
     {
         get => spawnModel = GetNodeFromRefTable(spawnModel, spawnModelFile) as CGameSpawnModel;
@@ -117,42 +130,55 @@ public abstract class CGameCtnBlockInfoVariant : CMwNod
     }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B006), sinceVersion: 10)]
     public CPlugEntitySpawner?[]? EntitySpawners { get => entitySpawners; set => entitySpawners = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B007))]
     public CPlugProbe? Probe { get => probe; set => probe = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B008))]
     public CGameCtnBlockUnitInfo?[]? BlockUnitModels { get => blockUnitModels; set => blockUnitModels = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B008))]
     public bool HasManualSymmetryH { get => hasManualSymmetryH; set => hasManualSymmetryH = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B008))]
     public bool HasManualSymmetryV { get => hasManualSymmetryV; set => hasManualSymmetryV = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B008))]
     public bool HasManualSymmetryD1 { get => hasManualSymmetryD1; set => hasManualSymmetryD1 = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B008))]
     public bool HasManualSymmetryD2 { get => hasManualSymmetryD2; set => hasManualSymmetryD2 = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B008), sinceVersion: 0, upToVersion: 1)] // version 2+ exist but they are not currently retrievable
     public Vec3 SpawnTrans { get => spawnTrans; set => spawnTrans = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B008), sinceVersion: 0, upToVersion: 1)] // version 2+ exist but they are not currently retrievable
     public float SpawnYaw { get => spawnYaw; set => spawnYaw = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B008), sinceVersion: 0, upToVersion: 1)] // version 2+ exist but they are not currently retrievable
     public float SpawnPitch { get => spawnPitch; set => spawnPitch = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B008))]
     public string? Name { get => name; set => name = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B00A), sinceVersion: 2)] // they could be above ver. 2 but they wont be available here
     public CGameObjectPhyCompoundModel? CompoundModel { get => compoundModel; set => compoundModel = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315B00A), sinceVersion: 2)] // they could be above ver. 2 but they wont be available here
     public Iso4 CompoundLoc { get => compoundLoc; set => compoundLoc = value; }
 
     protected CGameCtnBlockInfoVariant()

--- a/Src/GBX.NET/Engines/Game/CGameCtnBlockInfoVariantGround.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnBlockInfoVariantGround.cs
@@ -26,12 +26,15 @@ public class CGameCtnBlockInfoVariantGround : CGameCtnBlockInfoVariant
     #region Properties
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315C001))]
     public CGameCtnAutoTerrain?[]? AutoTerrains { get => autoTerrains; set => autoTerrains = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315C001))]
     public int AutoTerrainHeightOffset { get => autoTerrainHeightOffset; set => autoTerrainHeightOffset = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0315C001))]
     public EAutoTerrainPlaceType AutoTerrainPlaceType { get => autoTerrainPlaceType; set => autoTerrainPlaceType = value; }
 
     #endregion

--- a/Src/GBX.NET/Engines/Game/CGameCtnBlockSkin.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnBlockSkin.cs
@@ -19,18 +19,25 @@ public class CGameCtnBlockSkin : CMwNod
     #region Properties
 
     [NodeMember]
+    [AppliedWithChunk(typeof(Chunk03059000))]
+    [AppliedWithChunk(typeof(Chunk03059001))]
+    [AppliedWithChunk(typeof(Chunk03059002))]
     public string? Text { get => text; set => text = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03059001))]
+    [AppliedWithChunk(typeof(Chunk03059002))]
     public FileRef? PackDesc { get => packDesc; set => packDesc = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03059002))]
     public FileRef? ParentPackDesc { get => parentPackDesc; set => parentPackDesc = value; }
 
     /// <summary>
     /// Second skin for the skinnable block. Available in TM®.
     /// </summary>
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03059003))]
     public FileRef? ForegroundPackDesc { get => foregroundPackDesc; set => foregroundPackDesc = value; }
 
     #endregion

--- a/Src/GBX.NET/Engines/Game/CGameCtnBlockUnitInfo.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnBlockUnitInfo.cs
@@ -23,18 +23,23 @@ public class CGameCtnBlockUnitInfo : CMwNod
     #region Properties
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03036000))]
     public int PlacePylons { get => placePylons; set => placePylons = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03036004))]
     public int AcceptPylons { get => acceptPylons; set => acceptPylons = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03036000))]
     public Int3 RelativeOffset { get => relativeOffset; set => relativeOffset = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03036000))]
     public ExternalNode<CGameCtnBlockInfoClip>[]? Clips { get => clips; set => clips = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03036002))]
     public bool Underground
     {
         get
@@ -50,9 +55,12 @@ public class CGameCtnBlockUnitInfo : CMwNod
     }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03036005))]
     public string? TerrainModifierId { get => terrainModifierId; set => terrainModifierId = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03036008))]
+    [AppliedWithChunk(typeof(Chunk0303600B))]
     public CGameCtnBlockInfoClip? BottomClip
     {
         get => bottomClip = GetNodeFromRefTable(bottomClip, bottomClipFile) as CGameCtnBlockInfoClip;
@@ -60,6 +68,8 @@ public class CGameCtnBlockUnitInfo : CMwNod
     }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk03036008))]
+    [AppliedWithChunk(typeof(Chunk0303600B))]
     public CGameCtnBlockInfoClip? TopClip
     {
         get => topClip = GetNodeFromRefTable(topClip, topClipFile) as CGameCtnBlockInfoClip;
@@ -67,9 +77,11 @@ public class CGameCtnBlockUnitInfo : CMwNod
     }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0303600B))]
     public Direction BottomClipDir { get => bottomClipDir; set => bottomClipDir = value; }
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk(typeof(Chunk0303600B))]
     public Direction TopClipDir { get => topClipDir; set => topClipDir = value; }
 
     #endregion

--- a/Src/GBX.NET/Engines/Game/CGameCtnCampaign.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnCampaign.cs
@@ -194,7 +194,7 @@ public class CGameCtnCampaign : CMwNod
     public string? ModeScriptName { get => modeScriptName; set => modeScriptName = value; }
 
     [NodeMember(ExactlyNamed = true)]
-    [AppliedWithChunk(typeof(Chunk03090012))]
+    [AppliedWithChunk(typeof(Chunk03090012), sinceVersion: 0, upToVersion: 1)]
     public string? ScoreContext
     {
         get
@@ -252,7 +252,7 @@ public class CGameCtnCampaign : CMwNod
 
         public override void ReadWrite(CGameCtnCampaign n, GameBoxReaderWriter rw)
         {
-            rw.Int32(ref version);
+            rw.Int32(ref version); // 10?
             rw.ArrayNode(ref n.mapGroups!);
         }
     }

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.BotPath.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.BotPath.cs
@@ -10,35 +10,11 @@ public partial class CGameCtnChallenge
         private CGameWaypointSpecialProperty? waypointSpecialProperty;
         private bool isAutonomous;
 
-        public int Clan
-        {
-            get => clan;
-            set => clan = value;
-        }
-
-        public IList<Vec3>? Path
-        {
-            get => path;
-            set => path = value;
-        }
-
-        public bool IsFlying
-        {
-            get => isFlying;
-            set => isFlying = value;
-        }
-
-        public CGameWaypointSpecialProperty? WaypointSpecialProperty
-        {
-            get => waypointSpecialProperty;
-            set => waypointSpecialProperty = value;
-        }
-
-        public bool IsAutonomous
-        {
-            get => isAutonomous;
-            set => isAutonomous = value;
-        }
+        public int Clan { get => clan; set => clan = value; }
+        public IList<Vec3>? Path { get => path; set => path = value; }
+        public bool IsFlying { get => isFlying; set => isFlying = value; }
+        public CGameWaypointSpecialProperty? WaypointSpecialProperty { get => waypointSpecialProperty; set => waypointSpecialProperty = value; }
+        public bool IsAutonomous { get => isAutonomous; set => isAutonomous = value; }
 
         internal void ReadWrite(GameBoxReaderWriter rw)
         {

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.SBakedClipsAdditionalData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.SBakedClipsAdditionalData.cs
@@ -1,0 +1,6 @@
+﻿namespace GBX.NET.Engines.Game;
+
+public partial class CGameCtnChallenge
+{
+    public record SBakedClipsAdditionalData(Ident Clip1, Ident Clip2, Ident Clip3, Ident Clip4, Int3 Coord);
+}

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -2804,7 +2804,6 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
             }
 
             var nbBlocks = r.ReadInt32();
-            var hasUnassignedBlocks = false;
 
             n.blocks = new List<CGameCtnBlock>(nbBlocks);
 
@@ -2817,17 +2816,12 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
                     continue;
                 }
 
-                hasUnassignedBlocks = true;
-
                 i--;
             }
 
-            if (hasUnassignedBlocks)
+            while ((r.PeekUInt32() & 0xC0000000) > 0)
             {
-                while ((r.PeekUInt32() & 0xC0000000) > 0)
-                {
-                    ReadAndAddBlock(n, r, version);
-                }
+                ReadAndAddBlock(n, r, version);
             }
         }
 
@@ -3686,7 +3680,6 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
             U01 = r.ReadInt32();
 
             var count = r.ReadInt32();
-            var hasUnassignedBlocks = false;
 
             n.BakedBlocks = new List<CGameCtnBlock>(count);
 
@@ -3696,17 +3689,13 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
                 if (flags == -1)
                 {
-                    hasUnassignedBlocks = true;
                     i--;
                 }
             }
 
-            if (hasUnassignedBlocks)
+            while ((r.PeekUInt32() & 0xC0000000) > 0)
             {
-                while ((r.PeekUInt32() & 0xC0000000) > 0)
-                {
-                    ReadAndAddBakedBlock(n, r);
-                }
+                ReadAndAddBakedBlock(n, r);
             }
 
             U02 = r.ReadInt32();

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -191,6 +191,8 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     private Vec3? thumbnailPosition;
     private Vec3? thumbnailPitchYawRoll;
     private float? thumbnailFOV;
+    private float? thumbnailNearClipPlane;
+    private float? thumbnailFarClipPlane;
     private IList<CGameCtnAnchoredObject>? anchoredObjects;
     private CScriptTraitsMetadata? scriptMetadata;
     private List<List<EmbeddedFile>>? lightmapFrames;
@@ -656,8 +658,16 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     [SupportsFormatting]
     public string? Comments
     {
-        get => comments;
-        set => comments = value;
+        get
+        {
+            DiscoverChunk<Chunk03043036>();
+            return comments;
+        }
+        set
+        {
+            DiscoverChunk<Chunk03043036>();
+            comments = value;
+        }
     }
 
     [NodeMember]
@@ -999,6 +1009,36 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
         {
             DiscoverChunk<Chunk03043036>();
             thumbnailFOV = value;
+        }
+    }
+
+    [NodeMember]
+    public float? ThumbnailNearClipPlane
+    {
+        get
+        {
+            DiscoverChunk<Chunk03043036>();
+            return thumbnailNearClipPlane;
+        }
+        set
+        {
+            DiscoverChunk<Chunk03043036>();
+            thumbnailNearClipPlane = value;
+        }
+    }
+
+    [NodeMember]
+    public float? ThumbnailFarClipPlane
+    {
+        get
+        {
+            DiscoverChunk<Chunk03043036>();
+            return thumbnailFarClipPlane;
+        }
+        set
+        {
+            DiscoverChunk<Chunk03043036>();
+            thumbnailFarClipPlane = value;
         }
     }
 
@@ -3173,15 +3213,16 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
     #endregion
 
-    #region 0x036 skippable chunk (realtime thumbnail)
+    #region 0x036 skippable chunk (realtime thumbnail + comments)
 
     /// <summary>
-    /// CGameCtnChallenge 0x036 skippable chunk (realtime thumbnail)
+    /// CGameCtnChallenge 0x036 skippable chunk (realtime thumbnail + comments)
     /// </summary>
-    [Chunk(0x03043036, "realtime thumbnail")]
+    [Chunk(0x03043036, "realtime thumbnail + comments")]
     public class Chunk03043036 : SkippableChunk<CGameCtnChallenge>
     {
-        public byte[]? U01;
+        public float U01 = 10;
+        public float U02 = 0; // depth? 0 or 0.02
 
         public override void ReadWrite(CGameCtnChallenge n, GameBoxReaderWriter rw)
         {
@@ -3190,17 +3231,13 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
             rw.Vec3(ref n.thumbnailPitchYawRoll);
 
             // GmLensVal
-            rw.Single(ref n.thumbnailFOV);
+            rw.Single(ref n.thumbnailFOV, defaultValue: 90);
+            rw.Single(ref U01); // always 10
+            rw.Single(ref U02); // depth? 0 or 0.02
+            rw.Single(ref n.thumbnailNearClipPlane, defaultValue: -1);
+            rw.Single(ref n.thumbnailFarClipPlane, defaultValue: -1);
 
-            if (rw.Reader is not null)
-            {
-                U01 = rw.Reader.ReadBytes((int)(rw.Reader.BaseStream.Length - rw.Reader.BaseStream.Position));
-            }
-
-            if (rw.Writer is not null)
-            {
-                rw.Writer.Write(U01);
-            }
+            rw.String(ref n.comments);
         }
     }
 

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -211,6 +211,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     private TimeSpan? dayTime;
     private bool dynamicDaylight;
     private TimeInt32? dayDuration;
+    private bool? hasCustomCamThumbnail;
 
     #endregion
 
@@ -1314,6 +1315,12 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
             dayDuration = value;
         }
     }
+
+    /// <summary>
+    /// If the thumbnail camera was customized. Only relevant up to TMUF.
+    /// </summary>
+    [NodeMember]
+    public bool? HasCustomCamThumbnail { get => hasCustomCamThumbnail; set => hasCustomCamThumbnail = value; }
 
     #endregion
 
@@ -3111,31 +3118,31 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     [Chunk(0x03043027)]
     public class Chunk03043027 : Chunk<CGameCtnChallenge>
     {
-        public bool ArchiveGmCamVal;
         public byte U01;
         public Vec3 U02;
         public Vec3 U03;
         public Vec3 U04;
-        public float U05;
-        public float U06;
 
         public override void ReadWrite(CGameCtnChallenge n, GameBoxReaderWriter rw)
         {
-            rw.Boolean(ref ArchiveGmCamVal);
+            rw.Boolean(ref n.hasCustomCamThumbnail);
 
-            if (ArchiveGmCamVal)
+            if (!n.hasCustomCamThumbnail.GetValueOrDefault())
             {
-                rw.Byte(ref U01);
-
-                rw.Vec3(ref U02);
-                rw.Vec3(ref U03);
-                rw.Vec3(ref U04);
-
-                rw.Vec3(ref n.thumbnailPosition);
-                rw.Single(ref n.thumbnailFOV);
-                rw.Single(ref U05);
-                rw.Single(ref U06);
+                return;
             }
+
+            rw.Byte(ref U01);
+
+            // Iso4
+            rw.Vec3(ref U02);
+            rw.Vec3(ref U03); // camera calibration matrix?
+            rw.Vec3(ref U04);
+            rw.Vec3(ref n.thumbnailPosition);
+
+            rw.Single(ref n.thumbnailFOV);
+            rw.Single(ref n.thumbnailNearClipPlane);
+            rw.Single(ref n.thumbnailFarClipPlane);
         }
     }
 

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -1,8 +1,6 @@
 ﻿using System.IO.Compression;
 using System.Security;
-using System.Security.Cryptography;
 using System.Text;
-using System.Linq;
 using GBX.NET.BlockInfo;
 
 namespace GBX.NET.Engines.Game;
@@ -225,16 +223,14 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     [NodeMember]
     public TimeInt32? TMObjective_BronzeTime
     {
-        get
-        {
-            if (ChallengeParameters != null)
-                return ChallengeParameters.BronzeTime;
-            return bronzeTime;
-        }
+        get => ChallengeParameters is null ? bronzeTime : ChallengeParameters.BronzeTime;
         set
         {
-            if (ChallengeParameters != null)
+            if (ChallengeParameters is not null)
+            {
                 ChallengeParameters.BronzeTime = value;
+            }
+
             bronzeTime = value;
         }
     }
@@ -245,16 +241,14 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     [NodeMember]
     public TimeInt32? TMObjective_SilverTime
     {
-        get
-        {
-            if (ChallengeParameters != null)
-                return ChallengeParameters.SilverTime;
-            return silverTime;
-        }
+        get => ChallengeParameters is null ? silverTime : ChallengeParameters.SilverTime;
         set
         {
-            if (ChallengeParameters != null)
+            if (ChallengeParameters is not null)
+            {
                 ChallengeParameters.SilverTime = value;
+            }
+
             silverTime = value;
         }
     }
@@ -265,16 +259,14 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     [NodeMember]
     public TimeInt32? TMObjective_GoldTime
     {
-        get
-        {
-            if (ChallengeParameters != null)
-                return ChallengeParameters.GoldTime;
-            return goldTime;
-        }
+        get => ChallengeParameters is null ? goldTime : ChallengeParameters.GoldTime;
         set
         {
-            if (ChallengeParameters != null)
+            if (ChallengeParameters is not null)
+            {
                 ChallengeParameters.GoldTime = value;
+            }
+
             goldTime = value;
         }
     }
@@ -285,16 +277,14 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     [NodeMember]
     public TimeInt32? TMObjective_AuthorTime
     {
-        get
-        {
-            if (ChallengeParameters != null)
-                return ChallengeParameters.AuthorTime;
-            return authorTime;
-        }
+        get => ChallengeParameters is null ? authorTime : ChallengeParameters.AuthorTime;
         set
         {
-            if (ChallengeParameters != null)
+            if (ChallengeParameters is not null)
+            {
                 ChallengeParameters.AuthorTime = value;
+            }
+
             authorTime = value;
         }
     }
@@ -303,11 +293,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     /// Display cost of the track (or copper cost) explaining the performance of the map.
     /// </summary>
     [NodeMember]
-    public int? Cost
-    {
-        get => cost;
-        set => cost = value;
-    }
+    public int? Cost { get => cost; set => cost = value; }
 
     /// <summary>
     /// Usually author time or stunts score. If <see cref="ChallengeParameters"/> is available, it uses the value from there instead.
@@ -315,16 +301,14 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     [NodeMember]
     public int? AuthorScore
     {
-        get
-        {
-            if (ChallengeParameters != null)
-                return ChallengeParameters.AuthorScore;
-            return authorScore;
-        }
+        get => ChallengeParameters is null ? authorScore : ChallengeParameters.AuthorScore;
         set
         {
-            if (ChallengeParameters != null)
+            if (ChallengeParameters is not null)
+            {
                 ChallengeParameters.AuthorScore = value;
+            }
+
             authorScore = value;
         }
     }
@@ -333,11 +317,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     /// In which editor settings the map was made.
     /// </summary>
     [NodeMember]
-    public EditorMode Editor
-    {
-        get => editor;
-        set => editor = value;
-    }
+    public EditorMode Editor { get => editor; set => editor = value; }
 
     /// <summary>
     /// If the map was made using the simple editor.
@@ -391,21 +371,13 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     /// Number of checkpoints.
     /// </summary>
     [NodeMember]
-    public int? NbCheckpoints
-    {
-        get => nbCheckpoints;
-        set => nbCheckpoints = value;
-    }
+    public int? NbCheckpoints { get => nbCheckpoints; set => nbCheckpoints = value; }
 
     /// <summary>
     /// Map UID, environment, and author login.
     /// </summary>
     [NodeMember]
-    public Ident MapInfo
-    {
-        get => mapInfo;
-        set => mapInfo = value;
-    }
+    public Ident MapInfo { get => mapInfo; set => mapInfo = value; }
 
     /// <summary>
     /// The map's UID.
@@ -414,10 +386,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     public string MapUid
     {
         get => mapInfo.Id;
-        set
-        {
-            mapInfo = new Ident(value, mapInfo.Collection, mapInfo.Author);
-        }
+        set => mapInfo = new Ident(value, mapInfo.Collection, mapInfo.Author);
     }
 
     /// <summary>
@@ -430,12 +399,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
         {
             DiscoverChunk<Chunk03043042>();
 
-            if (authorLogin is null)
-            {
-                return mapInfo.Author;
-            }
-
-            return authorLogin;
+            return authorLogin is null ? mapInfo.Author : authorLogin;
         }
         set
         {
@@ -451,31 +415,19 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     /// </summary>
     [NodeMember]
     [SupportsFormatting]
-    public string MapName
-    {
-        get => mapName;
-        set => mapName = value;
-    }
+    public string MapName { get => mapName; set => mapName = value; }
 
     /// <summary>
     /// The map's intended use or state, defined in the header. This defines the visibility in the the map browser.
     /// </summary>
     [NodeMember]
-    public MapKind KindInHeader
-    {
-        get => kindInHeader;
-        set => kindInHeader = value;
-    }
+    public MapKind KindInHeader { get => kindInHeader; set => kindInHeader = value; }
 
     /// <summary>
     /// The map's intended use or state, defined in the body. This defines general validity.
     /// </summary>
     [NodeMember]
-    public MapKind Kind
-    {
-        get => kind;
-        set => kind = value;
-    }
+    public MapKind Kind { get => kind; set => kind = value; }
 
     /// <summary>
     /// Password of the map used by older maps.
@@ -499,11 +451,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     /// The map's decoration (time of the day or scenery)
     /// </summary>
     [NodeMember]
-    public Ident? Decoration
-    {
-        get => decoration;
-        set => decoration = value;
-    }
+    public Ident? Decoration { get => decoration; set => decoration = value; }
 
     /// <summary>
     /// Name of the map type script.
@@ -511,16 +459,14 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     [NodeMember]
     public string? MapType
     {
-        get
-        {
-            if (ChallengeParameters != null)
-                return ChallengeParameters.MapType;
-            return mapType;
-        }
+        get => ChallengeParameters is null ? mapType : ChallengeParameters.MapType;
         set
         {
-            if (ChallengeParameters != null)
+            if (ChallengeParameters is not null)
+            {
                 ChallengeParameters.MapType = value;
+            }
+
             mapType = value;
         }
     }
@@ -531,16 +477,14 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     [NodeMember]
     public string? MapStyle
     {
-        get
-        {
-            if (ChallengeParameters != null)
-                return ChallengeParameters.MapStyle;
-            return mapStyle;
-        }
+        get => ChallengeParameters is null ? mapStyle : ChallengeParameters.MapStyle;
         set
         {
-            if (ChallengeParameters != null)
+            if (ChallengeParameters is not null)
+            {
                 ChallengeParameters.MapStyle = value;
+            }
+
             mapStyle = value;
         }
     }
@@ -549,42 +493,26 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     /// UID of the lightmap data stored in cache.
     /// </summary>
     [NodeMember]
-    public ulong? LightmapCacheUID
-    {
-        get => lightmapCacheUID;
-        set => lightmapCacheUID = value;
-    }
+    public ulong? LightmapCacheUID { get => lightmapCacheUID; set => lightmapCacheUID = value; }
 
     /// <summary>
     /// Version of the lightmap calculation.
     /// </summary>
     [NodeMember]
-    public byte? LightmapVersion
-    {
-        get => lightmapVersion;
-        set => lightmapVersion = value;
-    }
+    public byte? LightmapVersion { get => lightmapVersion; set => lightmapVersion = value; }
 
     /// <summary>
     /// XML track information and dependencies.
     /// </summary>
     [NodeMember]
-    public string? XML
-    {
-        get => xml;
-        set => xml = value;
-    }
+    public string? XML { get => xml; set => xml = value; }
 
     /// <summary>
     /// Thumbnail JPEG data.
     /// </summary>
     [NodeMember]
     [JpegData]
-    public byte[]? Thumbnail
-    {
-        get => thumbnail;
-        set => thumbnail = value;
-    }
+    public byte[]? Thumbnail { get => thumbnail; set => thumbnail = value; }
 
     /// <summary>
     /// The map's environment.
@@ -600,21 +528,13 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     /// Origin of the map.
     /// </summary>
     [NodeMember]
-    public Vec2? MapCoordOrigin
-    {
-        get => mapCoordOrigin;
-        set => mapCoordOrigin = value;
-    }
+    public Vec2? MapCoordOrigin { get => mapCoordOrigin; set => mapCoordOrigin = value; }
 
     /// <summary>
     /// Target of the map.
     /// </summary>
     [NodeMember]
-    public Vec2? MapCoordTarget
-    {
-        get => mapCoordTarget;
-        set => mapCoordTarget = value;
-    }
+    public Vec2? MapCoordTarget { get => mapCoordTarget; set => mapCoordTarget = value; }
 
     /// <summary>
     /// Title pack the map was built in.
@@ -742,31 +662,19 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     /// The car's name, environment and author used on the map.
     /// </summary>
     [NodeMember]
-    public Ident? PlayerModel
-    {
-        get => playerModel;
-        set => playerModel = value;
-    }
+    public Ident? PlayerModel { get => playerModel; set => playerModel = value; }
 
     /// <summary>
     /// Map parameters.
     /// </summary>
     [NodeMember]
-    public CGameCtnChallengeParameters? ChallengeParameters
-    {
-        get => challengeParameters;
-        set => challengeParameters = value;
-    }
+    public CGameCtnChallengeParameters? ChallengeParameters { get => challengeParameters; set => challengeParameters = value; }
 
     /// <summary>
     /// List of available puzzle pieces.
     /// </summary>
     [NodeMember]
-    public CGameCtnCollectorList? BlockStock
-    {
-        get => blockStock;
-        set => blockStock = value;
-    }
+    public CGameCtnCollectorList? BlockStock { get => blockStock; set => blockStock = value; }
 
     /// <summary>
     /// All checkpoints and their map coordinates. Used by TMUF and older games.
@@ -826,18 +734,10 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     /// Size of the map in block coordinates.
     /// </summary>
     [NodeMember]
-    public Int3? Size
-    {
-        get => size;
-        set => size = value;
-    }
+    public Int3? Size { get => size; set => size = value; }
 
     [NodeMember]
-    public bool? NeedUnlock
-    {
-        get => needUnlock;
-        set => needUnlock = value;
-    }
+    public bool? NeedUnlock { get => needUnlock; set => needUnlock = value; }
 
     /// <summary>
     /// List of all blocks on the map. Can be null when only the header was read, or simply when <see cref="Chunk0304300F"/>, <see cref="Chunk03043013"/>, or <see cref="Chunk0304301F"/> is missing.
@@ -867,61 +767,37 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     /// MediaTracker intro.
     /// </summary>
     [NodeMember]
-    public CGameCtnMediaClip? ClipIntro
-    {
-        get => clipIntro;
-        set => clipIntro = value;
-    }
+    public CGameCtnMediaClip? ClipIntro { get => clipIntro; set => clipIntro = value; }
 
     /// <summary>
     /// MediaTracker ingame.
     /// </summary>
     [NodeMember]
-    public CGameCtnMediaClipGroup? ClipGroupInGame
-    {
-        get => clipGroupInGame;
-        set => clipGroupInGame = value;
-    }
+    public CGameCtnMediaClipGroup? ClipGroupInGame { get => clipGroupInGame; set => clipGroupInGame = value; }
 
     /// <summary>
     /// MediaTracker end race.
     /// </summary>
     [NodeMember]
-    public CGameCtnMediaClipGroup? ClipGroupEndRace
-    {
-        get => clipGroupEndRace;
-        set => clipGroupEndRace = value;
-    }
+    public CGameCtnMediaClipGroup? ClipGroupEndRace { get => clipGroupEndRace; set => clipGroupEndRace = value; }
 
     /// <summary>
     /// MediaTracker ambiance.
     /// </summary>
     [NodeMember]
-    public CGameCtnMediaClip? ClipAmbiance
-    {
-        get => clipAmbiance;
-        set => clipAmbiance = value;
-    }
+    public CGameCtnMediaClip? ClipAmbiance { get => clipAmbiance; set => clipAmbiance = value; }
 
     /// <summary>
     /// MediaTracker podium.
     /// </summary>
     [NodeMember]
-    public CGameCtnMediaClip? ClipPodium
-    {
-        get => clipPodium;
-        set => clipPodium = value;
-    }
+    public CGameCtnMediaClip? ClipPodium { get => clipPodium; set => clipPodium = value; }
 
     /// <summary>
     /// Reference to the custom music used on the map.
     /// </summary>
     [NodeMember]
-    public FileRef? CustomMusicPackDesc
-    {
-        get => customMusicPackDesc;
-        set => customMusicPackDesc = value;
-    }
+    public FileRef? CustomMusicPackDesc { get => customMusicPackDesc; set => customMusicPackDesc = value; }
 
     /// <summary>
     /// Hashed password of the map, if it's password protected.
@@ -1557,6 +1433,8 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
         RemoveChunk<Chunk03043021>();
 
+        return true;
+
         static void ConvertMediaClip(CGameCtnMediaClip? node)
         {
             if (node is null)
@@ -1615,8 +1493,6 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
             // FX Bloom is no longer supported and was remade into FxBloomHdr
             // TODO: convert to fx bloom hdr effectively
         }
-
-        return true;
     }
 
     /// <summary>
@@ -2547,21 +2423,13 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     /// CGameCtnChallenge 0x00F chunk (TM1.0 block data)
     /// </summary>
     [Chunk(0x0304300F, "TM1.0 block data")]
-    public class Chunk0304300F : Chunk<CGameCtnChallenge>, IVersionable
+    public class Chunk0304300F : Chunk<CGameCtnChallenge>
     {
-        private int version;
-
-        public int Version
-        {
-            get => version;
-            set => version = value;
-        }
-
         public override void ReadWrite(CGameCtnChallenge n, GameBoxReaderWriter rw)
         {
             rw.Ident(ref n.mapInfo!);
             rw.Int3(ref n.size);
-            rw.Int32(ref version);
+            rw.Int32(10);
             rw.ListNode<CGameCtnBlock>(ref n.blocks!);
             rw.Boolean(ref n.needUnlock);
             rw.Ident(ref n.decoration);
@@ -2571,7 +2439,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
         {
             rw.Ident(ref n.mapInfo!);
             rw.Int3(ref n.size);
-            rw.Int32(ref version);
+            rw.Int32(10);
             n.blocks = (await rw.ListNodeAsync<CGameCtnBlock>(n.blocks!, cancellationToken))!;
             rw.Boolean(ref n.needUnlock);
             rw.Ident(ref n.decoration);
@@ -2742,25 +2610,30 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
         public override void ReadWrite(CGameCtnChallenge n, GameBoxReaderWriter rw)
         {
-            rw.NodeRef(ref U01);
+            rw.NodeRef(ref U01); // assert: '!ReplayRecord || !ReplayRecord->m_Challenge' failed.
         }
     }
 
     #endregion
 
-    #region 0x01B chunk
+    #region 0x01B chunk (OldIgs)
 
     /// <summary>
-    /// CGameCtnChallenge 0x01B chunk
+    /// CGameCtnChallenge 0x01B chunk (OldIgs)
     /// </summary>
-    [Chunk(0x0304301B)]
+    [Chunk(0x0304301B, "OldIgs")]
     public class Chunk0304301B : Chunk<CGameCtnChallenge>
     {
         public int U01;
 
         public override void ReadWrite(CGameCtnChallenge n, GameBoxReaderWriter rw)
         {
-            rw.Int32(ref U01);
+            rw.Int32(ref U01); // SOldIgs array
+
+            if (U01 > 0)
+            {
+                throw new NotSupportedException("SOldIgs count > 0");
+            }
         }
     }
 
@@ -2794,7 +2667,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
         public override void ReadWrite(CGameCtnChallenge n, GameBoxReaderWriter rw)
         {
-            rw.NodeRef(ref U01);
+            rw.NodeRef(ref U01); // assert: '!ReplayRecord || !ReplayRecord->m_Challenge' failed.
         }
     }
 
@@ -3094,7 +2967,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     [Chunk(0x03043026, "clip global")]
     public class Chunk03043026 : Chunk<CGameCtnChallenge>
     {
-        public CMwNod? clipGlobal;
+        private CMwNod? clipGlobal;
 
         public CMwNod? ClipGlobal
         {
@@ -3110,10 +2983,10 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
     #endregion
 
-    #region 0x027 chunk
+    #region 0x027 chunk (old realtime thumbnail)
 
     /// <summary>
-    /// CGameCtnChallenge 0x027 chunk
+    /// CGameCtnChallenge 0x027 chunk (old realtime thumbnail)
     /// </summary>
     [Chunk(0x03043027)]
     public class Chunk03043027 : Chunk<CGameCtnChallenge>
@@ -3148,24 +3021,17 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
     #endregion
 
-    #region 0x028 chunk (comments)
+    #region 0x028 chunk (old realtime thumbnail + comments)
 
     /// <summary>
-    /// CGameCtnChallenge 0x028 chunk (comments)
+    /// CGameCtnChallenge 0x028 chunk (old realtime thumbnail + comments)
     /// </summary>
     [Chunk(0x03043028, "comments")]
-    public class Chunk03043028 : Chunk<CGameCtnChallenge>
+    public class Chunk03043028 : Chunk03043027
     {
-        public Chunk03043027 Chunk027 { get; }
-
-        public Chunk03043028()
-        {
-            Chunk027 = new Chunk03043027();
-        }
-
         public override void ReadWrite(CGameCtnChallenge n, GameBoxReaderWriter rw)
         {
-            Chunk027.ReadWrite(n, rw);
+            base.ReadWrite(n, rw);
             rw.String(ref n.comments);
         }
     }
@@ -3201,32 +3067,19 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
         public override void ReadWrite(CGameCtnChallenge n, GameBoxReaderWriter rw)
         {
-            rw.Boolean(ref U01);
+            rw.Boolean(ref U01); // code hints to something with locking (NeedUnlock?)
         }
     }
 
     #endregion
 
-    #region 0x034 skippable chunk
+    #region 0x02D skippable chunk (realtime thumbnail + comments)
 
     /// <summary>
-    /// CGameCtnChallenge 0x034 skippable chunk
+    /// CGameCtnChallenge 0x02D skippable chunk (realtime thumbnail + comments)
     /// </summary>
-    [Chunk(0x03043034), IgnoreChunk]
-    public class Chunk03043034 : SkippableChunk<CGameCtnChallenge>
-    {
-
-    }
-
-    #endregion
-
-    #region 0x036 skippable chunk (realtime thumbnail + comments)
-
-    /// <summary>
-    /// CGameCtnChallenge 0x036 skippable chunk (realtime thumbnail + comments)
-    /// </summary>
-    [Chunk(0x03043036, "realtime thumbnail + comments")]
-    public class Chunk03043036 : SkippableChunk<CGameCtnChallenge>
+    [Chunk(0x0304302D, "realtime thumbnail + comments")]
+    public class Chunk0304302D : SkippableChunk<CGameCtnChallenge>
     {
         public float U01 = 10;
         public float U02 = 0; // depth? 0 or 0.02
@@ -3250,6 +3103,37 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
     #endregion
 
+    #region 0x034 skippable chunk
+
+    /// <summary>
+    /// CGameCtnChallenge 0x034 skippable chunk
+    /// </summary>
+    [Chunk(0x03043034)]
+    public class Chunk03043034 : SkippableChunk<CGameCtnChallenge>
+    {
+        public byte[]? U01;
+
+        public override void ReadWrite(CGameCtnChallenge n, GameBoxReaderWriter rw)
+        {
+            rw.Bytes(ref U01); // ArchiveBufMem
+        }
+    }
+
+    #endregion
+
+    #region 0x036 skippable chunk (realtime thumbnail + comments)
+
+    /// <summary>
+    /// CGameCtnChallenge 0x036 skippable chunk (realtime thumbnail + comments)
+    /// </summary>
+    [Chunk(0x03043036, "realtime thumbnail + comments")]
+    public class Chunk03043036 : Chunk0304302D
+    {
+        
+    }
+
+    #endregion
+
     #region 0x038 skippable chunk
 
     /// <summary>
@@ -3258,7 +3142,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     [Chunk(0x03043038), IgnoreChunk]
     public class Chunk03043038 : SkippableChunk<CGameCtnChallenge>
     {
-
+        // refers to 0x03043031 which could be SChallengeCardEventIds?
     }
 
     #endregion
@@ -3448,17 +3332,39 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
         }
     }
 
-#endregion
+    #endregion
 
-    #region 0x03E skippable chunk
+    #region 0x03E skippable chunk (CSceneVehicleCarMarksSamples)
 
     /// <summary>
-    /// CGameCtnChallenge 0x03E skippable chunk
+    /// CGameCtnChallenge 0x03E skippable chunk (CSceneVehicleCarMarksSamples)
     /// </summary>
-    [Chunk(0x0304303E), IgnoreChunk]
-    public class Chunk0304303E : SkippableChunk<CGameCtnChallenge>
+    [Chunk(0x0304303E, "CSceneVehicleCarMarksSamples")]
+    public class Chunk0304303E : SkippableChunk<CGameCtnChallenge>, IVersionable
     {
+        private int version;
 
+        public int U01;
+
+        public int Version { get => version; set => version = value; }
+
+        public override void ReadWrite(CGameCtnChallenge n, GameBoxReaderWriter rw)
+        {
+            rw.Int32(ref version);
+
+            if (version > 0)
+            {
+                throw new ChunkVersionNotSupportedException(version);
+            }
+
+            rw.Int32(10);
+            rw.Int32(ref U01); // CSceneVehicleCarMarksSamples array
+
+            if (U01 > 0)
+            {
+                throw new NotSupportedException("U01 > 0");
+            }
+        }
     }
 
     #endregion
@@ -3473,7 +3379,6 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     public class Chunk03043040 : SkippableChunk<CGameCtnChallenge>, IVersionable
     {
         private int version = 4;
-        private int listVersion = 10;
 
         public int U01;
         public Int2[]? U02;
@@ -3494,8 +3399,8 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
             version = r.ReadInt32();
             U01 = r.ReadInt32();
             var size = r.ReadInt32();
-            listVersion = r.ReadInt32(); // 10
 
+            _ = r.ReadInt32(); // 10
             n.anchoredObjects = r.ReadList(r =>
             {
                 var node = Parse<CGameCtnAnchoredObject>(r, classId: null, progress: null, logger)!;
@@ -3539,7 +3444,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
             using var itemMs = new MemoryStream();
             using var itemW = new GameBoxWriter(itemMs, w.Settings, logger);
 
-            itemW.Write(listVersion);
+            itemW.Write(10);
             itemW.WriteNodeArray(n.anchoredObjects);
 
             if (version >= 1)
@@ -3584,22 +3489,18 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     [Chunk(0x03043042, "author")]
     public class Chunk03043042 : SkippableChunk<CGameCtnChallenge>, IVersionable
     {
-        private int version = 4;
+        private int version = 1;
 
         /// <summary>
         /// Version of the chunk.
         /// </summary>
-        public int Version
-        {
-            get => version;
-            set => version = value;
-        }
+        public int Version { get => version; set => version = value; }
 
         public override void ReadWrite(CGameCtnChallenge n, GameBoxReaderWriter rw)
         {
             rw.Int32(ref version);
             rw.Int32(ref n.authorVersion);
-            rw.String(ref n.authorLogin!);
+            rw.String(ref n.authorLogin!); // according to asserts, login must be larger than 0 and maybe equal to the MapInfo.Author
             rw.String(ref n.authorNickname);
             rw.String(ref n.authorZone);
             rw.String(ref n.authorExtraInfo);
@@ -3899,7 +3800,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     [Chunk(0x0304304F), IgnoreChunk]
     public class Chunk0304304F : SkippableChunk<CGameCtnChallenge>
     {
-
+        // possibly some enum
     }
 
     #endregion
@@ -4153,7 +4054,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     [Chunk(0x03043055), IgnoreChunk]
     public class Chunk03043055 : SkippableChunk<CGameCtnChallenge>
     {
-
+        // sets something to constant 1
     }
 
     #endregion
@@ -4194,7 +4095,35 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     [Chunk(0x03043057), IgnoreChunk]
     public class Chunk03043057 : SkippableChunk<CGameCtnChallenge>
     {
+        // additional stuff for bot paths
+    }
 
+    #endregion
+
+    #region 0x058 skippable chunk (SubMapsInfos)
+
+    /// <summary>
+    /// CGameCtnChallenge 0x058 skippable chunk (SubMapsInfos)
+    /// </summary>
+    [Chunk(0x03043058, "SubMapsInfos")]
+    public class Chunk03043058 : SkippableChunk<CGameCtnChallenge>
+    {
+        private int version;
+
+        public int U01;
+
+        public int Version { get => version; set => version = value; }
+
+        public override void ReadWrite(CGameCtnChallenge n, GameBoxReaderWriter rw)
+        {
+            rw.Int32(ref version);
+            rw.Int32(ref U01);
+
+            if (U01 > 0)
+            {
+                throw new NotSupportedException("U01 > 0");
+            }
+        }
     }
 
     #endregion
@@ -4210,18 +4139,14 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
         private int version;
 
         public Vec3 U01;
-        public bool U02;
-        public float U03;
-        public float U04;
+        public bool? U02;
+        public float? U03;
+        public float? U04;
 
         /// <summary>
         /// Version of the chunk.
         /// </summary>
-        public int Version
-        {
-            get => version;
-            set => version = value;
-        }
+        public int Version { get => version; set => version = value; }
 
         public override void ReadWrite(CGameCtnChallenge n, GameBoxReaderWriter rw)
         {
@@ -4229,9 +4154,19 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
             rw.Vec3(ref U01);
 
-            if (version != 0)
+            if (version == 0)
+            {
+                throw new VersionNotSupportedException(version);
+            }
+
+            if (version >= 1)
             {
                 rw.Boolean(ref U02);
+
+                if (U02.GetValueOrDefault())
+                {
+                    throw new NotSupportedException("U02 == true");
+                }
 
                 if (version >= 3)
                 {
@@ -4244,10 +4179,10 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
     #endregion
 
-    #region 0x05A skippable chunk
+    #region 0x05A skippable chunk [TM2020]
 
     /// <summary>
-    /// CGameCtnChallenge 0x05A skippable chunk [TM®️]
+    /// CGameCtnChallenge 0x05A skippable chunk [TM2020]
     /// </summary>
     [Chunk(0x0304305A)]
     public class Chunk0304305A : SkippableChunk<CGameCtnChallenge>
@@ -4264,12 +4199,12 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
     #endregion
 
-    #region 0x05B skippable chunk (lightmaps TM2020)
+    #region 0x05B skippable chunk (lightmaps) [TM2020]
 
     /// <summary>
-    /// CGameCtnChallenge 0x05B skippable chunk (lightmaps TM2020)
+    /// CGameCtnChallenge 0x05B skippable chunk (lightmaps) [TM2020]
     /// </summary>
-    [Chunk(0x0304305B, "lightmaps TM2020")]
+    [Chunk(0x0304305B, "lightmaps")]
     [ChunkWithOwnIdState]
     public class Chunk0304305B : SkippableChunk<CGameCtnChallenge>, IVersionable
     {
@@ -4280,11 +4215,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
         /// <summary>
         /// Version of the chunk.
         /// </summary>
-        public int Version
-        {
-            get => version;
-            set => version = value;
-        }
+        public int Version { get => version; set => version = value; }
 
         public bool U01;
         public bool U02;
@@ -4309,10 +4240,10 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
     #endregion
 
-    #region 0x05C skippable chunk
+    #region 0x05C skippable chunk [TM2020]
 
     /// <summary>
-    /// CGameCtnChallenge 0x05C skippable chunk
+    /// CGameCtnChallenge 0x05C skippable chunk [TM2020]
     /// </summary>
     [Chunk(0x0304305C), IgnoreChunk]
     public class Chunk0304305C : SkippableChunk<CGameCtnChallenge>
@@ -4322,10 +4253,10 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
     #endregion
 
-    #region 0x05D skippable chunk
+    #region 0x05D skippable chunk [TM2020]
 
     /// <summary>
-    /// CGameCtnChallenge 0x05D skippable chunk
+    /// CGameCtnChallenge 0x05D skippable chunk [TM2020]
     /// </summary>
     [Chunk(0x0304305D), IgnoreChunk]
     public class Chunk0304305D : SkippableChunk<CGameCtnChallenge>
@@ -4335,10 +4266,10 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
     #endregion
 
-    #region 0x05E skippable chunk
+    #region 0x05E skippable chunk [TM2020]
 
     /// <summary>
-    /// CGameCtnChallenge 0x05E skippable chunk
+    /// CGameCtnChallenge 0x05E skippable chunk [TM2020]
     /// </summary>
     [Chunk(0x0304305E), IgnoreChunk]
     public class Chunk0304305E : SkippableChunk<CGameCtnChallenge>
@@ -4382,10 +4313,10 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
     #endregion
 
-    #region 0x060 skippable chunk [TM®️]
+    #region 0x060 skippable chunk [TM2020]
 
     /// <summary>
-    /// CGameCtnChallenge 0x060 skippable chunk [TM®️]
+    /// CGameCtnChallenge 0x060 skippable chunk [TM2020]
     /// </summary>
     [Chunk(0x03043060), IgnoreChunk]
     public class Chunk03043060 : SkippableChunk<CGameCtnChallenge>
@@ -4395,10 +4326,10 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
     #endregion
 
-    #region 0x061 skippable chunk [TM®️]
+    #region 0x061 skippable chunk [TM2020]
 
     /// <summary>
-    /// CGameCtnChallenge 0x061 skippable chunk [TM®️]
+    /// CGameCtnChallenge 0x061 skippable chunk [TM2020]
     /// </summary>
     [Chunk(0x03043061), IgnoreChunk]
     public class Chunk03043061 : SkippableChunk<CGameCtnChallenge>
@@ -4408,10 +4339,10 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
     #endregion
 
-    #region 0x062 skippable chunk (block color) [TM®️]
+    #region 0x062 skippable chunk (block color) [TM2020]
 
     /// <summary>
-    /// CGameCtnChallenge 0x062 skippable chunk (block color) [TM®️]
+    /// CGameCtnChallenge 0x062 skippable chunk (block color) [TM2020]
     /// </summary>
     [Chunk(0x03043062, "block color")]
     public class Chunk03043062 : SkippableChunk<CGameCtnChallenge>, IVersionable
@@ -4479,10 +4410,10 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
     #endregion
 
-    #region 0x063 skippable chunk [TM®️]
+    #region 0x063 skippable chunk [TM2020]
 
     /// <summary>
-    /// CGameCtnChallenge 0x063 skippable chunk [TM®️]
+    /// CGameCtnChallenge 0x063 skippable chunk [TM2020]
     /// </summary>
     [Chunk(0x03043063), IgnoreChunk]
     public class Chunk03043063 : SkippableChunk<CGameCtnChallenge>
@@ -4492,10 +4423,10 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
     #endregion
 
-    #region 0x064 skippable chunk [TM®️]
+    #region 0x064 skippable chunk [TM2020]
 
     /// <summary>
-    /// CGameCtnChallenge 0x064 skippable chunk [TM®️]
+    /// CGameCtnChallenge 0x064 skippable chunk [TM2020]
     /// </summary>
     [Chunk(0x03043064), IgnoreChunk]
     public class Chunk03043064 : SkippableChunk<CGameCtnChallenge>
@@ -4505,13 +4436,52 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
     #endregion
 
-    #region 0x065 skippable chunk [TM®️]
+    #region 0x065 skippable chunk [TM2020]
 
     /// <summary>
-    /// CGameCtnChallenge 0x065 skippable chunk [TM®️]
+    /// CGameCtnChallenge 0x065 skippable chunk [TM2020]
     /// </summary>
     [Chunk(0x03043065), IgnoreChunk]
     public class Chunk03043065 : SkippableChunk<CGameCtnChallenge>
+    {
+
+    }
+
+    #endregion
+
+    #region 0x067 skippable chunk [TM2020]
+
+    /// <summary>
+    /// CGameCtnChallenge 0x067 skippable chunk [TM2020]
+    /// </summary>
+    [Chunk(0x03043067), IgnoreChunk]
+    public class Chunk03043067 : SkippableChunk<CGameCtnChallenge>
+    {
+
+    }
+
+    #endregion
+
+    #region 0x068 skippable chunk [TM2020]
+
+    /// <summary>
+    /// CGameCtnChallenge 0x068 skippable chunk [TM2020]
+    /// </summary>
+    [Chunk(0x03043068), IgnoreChunk]
+    public class Chunk03043068 : SkippableChunk<CGameCtnChallenge>
+    {
+
+    }
+
+    #endregion
+
+    #region 0x069 skippable chunk [TM2020]
+
+    /// <summary>
+    /// CGameCtnChallenge 0x069 skippable chunk [TM2020]
+    /// </summary>
+    [Chunk(0x03043069), IgnoreChunk]
+    public class Chunk03043069 : SkippableChunk<CGameCtnChallenge>
     {
 
     }

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -3668,7 +3668,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     /// <summary>
     /// CGameCtnChallenge 0x048 skippable chunk (baked blocks)
     /// </summary>
-    [Chunk(0x03043048, "baked blocks")]
+    [Chunk(0x03043048, processSync: true, "baked blocks")]
     public class Chunk03043048 : SkippableChunk<CGameCtnChallenge>, IVersionable
     {
         private int version;

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -845,6 +845,12 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     public IList<CGameCtnBlock>? BakedBlocks { get => bakedBlocks; set => bakedBlocks = value; }
 
     /// <summary>
+    /// Number of actual baked blocks on the map (doesn't include Unassigned1 and other blocks with <see cref="CGameCtnBlock.Flags"/> equal to -1).
+    /// </summary>
+    [NodeMember]
+    public int? NbBakedBlocks => BakedBlocks?.Count(x => x.Flags != -1);
+
+    /// <summary>
     /// MediaTracker intro.
     /// </summary>
     [NodeMember]
@@ -3729,9 +3735,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
             w.Write(U01);
 
-            var length = n.bakedBlocks?.Where(x => x.Flags != -1).Count() ?? 0;
-
-            w.Write(length);
+            w.Write(n.NbBakedBlocks.GetValueOrDefault());
 
             if (n.bakedBlocks is not null)
             {

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockCameraGame.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockCameraGame.cs
@@ -38,52 +38,48 @@ public class CGameCtnMediaBlockCameraGame : CGameCtnMediaBlockCamera, CGameCtnMe
     public EGameCam2? gameCam2;
     public int clipEntId = -1;
     public string? gameCam;
+    private Vec3? camPosition;
+    private Vec3? camPitchYawRoll;
+    private float? camFov;
+    private float? camNearClipPlane;
+    private float? camFarClipPlane;
 
     #endregion
 
     #region Properties
 
     [NodeMember]
-    public TimeSingle Start
-    {
-        get => start;
-        set => start = value;
-    }
+    public TimeSingle Start { get => start; set => start = value; }
 
     [NodeMember]
-    public TimeSingle End
-    {
-        get => end;
-        set => end = value;
-    }
+    public TimeSingle End { get => end; set => end = value; }
 
     [NodeMember]
-    public EGameCam? GameCam1
-    {
-        get => gameCam1;
-        set => gameCam1 = value;
-    }
+    public EGameCam? GameCam1 { get => gameCam1; set => gameCam1 = value; }
 
     [NodeMember]
-    public EGameCam2? GameCam2
-    {
-        get => gameCam2;
-        set => gameCam2 = value;
-    }
+    public EGameCam2? GameCam2 { get => gameCam2; set => gameCam2 = value; }
 
     [NodeMember]
-    public int ClipEntId
-    {
-        get => clipEntId;
-        set => clipEntId = value;
-    }
+    public int ClipEntId { get => clipEntId; set => clipEntId = value; }
 
     [NodeMember]
-    public string? GameCam
-    {
-        get => gameCam;
-        set => gameCam = value;
-    }
+    public string? GameCam { get => gameCam; set => gameCam = value; }
+
+    [NodeMember]
+    public Vec3? CamPosition { get => camPosition; set => camPosition = value; }
+
+    [NodeMember]
+    public Vec3? CamPitchYawRoll { get => camPitchYawRoll; set => camPitchYawRoll = value; }
+
+    [NodeMember]
+    public float? CamFov { get => camFov; set => camFov = value; }
+
+    [NodeMember]
+    public float? CamNearClipPlane { get => camNearClipPlane; set => camNearClipPlane = value; }
+
+    [NodeMember]
+    public float? CamFarClipPlane { get => camFarClipPlane; set => camFarClipPlane = value; }
 
     #endregion
 
@@ -264,8 +260,8 @@ public class CGameCtnMediaBlockCameraGame : CGameCtnMediaBlockCamera, CGameCtnMe
             set => version = value;
         }
 
-        public float[]? U01;
-        public float[]? U02;
+        public float U01 = 10;
+        public float U02 = 0; // depth? 0 or 0.02
         public bool U03;
         public bool U04;
         public bool U05;
@@ -292,9 +288,14 @@ public class CGameCtnMediaBlockCameraGame : CGameCtnMediaBlockCamera, CGameCtnMe
 
             // GmCamFreeVal
             // // GmLocFreeVal
-            rw.Array<float>(ref U01, count: 6);
+            rw.Vec3(ref n.camPosition);
+            rw.Vec3(ref n.camPitchYawRoll);
             // // GmLensVal
-            rw.Array<float>(ref U02, count: 5);
+            rw.Single(ref n.camFov, defaultValue: 90);
+            rw.Single(ref U01); // always 10
+            rw.Single(ref U02); // depth? 0 or 0.02
+            rw.Single(ref n.camNearClipPlane, defaultValue: -1);
+            rw.Single(ref n.camFarClipPlane, defaultValue: -1);
 
             rw.Boolean(ref U03);
             rw.Boolean(ref U04);

--- a/Src/GBX.NET/Engines/GameData/CGameCtnCollector.cs
+++ b/Src/GBX.NET/Engines/GameData/CGameCtnCollector.cs
@@ -74,6 +74,7 @@ public partial class CGameCtnCollector : CMwNod, CGameCtnCollector.IHeader
     public Color[,]? Icon { get; set; }
 
     [NodeMember]
+    [WebpData]
     public byte[]? IconWebP { get; set; }
 
     [NodeMember]

--- a/Src/GBX.NET/Engines/GameData/CGameCtnCollector.cs
+++ b/Src/GBX.NET/Engines/GameData/CGameCtnCollector.cs
@@ -232,7 +232,7 @@ public partial class CGameCtnCollector : CMwNod, CGameCtnCollector.IHeader
 
             for (var y = 0; y < height; y++)
                 for (var x = 0; x < width; x++)
-                    n.Icon[width - 1 - x, height - 1 - y] = Color.FromArgb(iconData[y * width + x]);
+                    n.Icon[x, height - 1 - y] = Color.FromArgb(iconData[y * width + x]);
         }
 
         public override void Write(CGameCtnCollector n, GameBoxWriter w)
@@ -269,7 +269,7 @@ public partial class CGameCtnCollector : CMwNod, CGameCtnCollector.IHeader
 
             for (var y = 0; y < height; y++)
                 for (var x = 0; x < width; x++)
-                    w.Write(n.Icon[width - 1 - x, height - 1 - y].ToArgb());
+                    w.Write(n.Icon[x, height - 1 - y].ToArgb());
         }
     }
 

--- a/Src/GBX.NET/GBX.NET.csproj
+++ b/Src/GBX.NET/GBX.NET.csproj
@@ -11,7 +11,7 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 
-		<Version>0.16.4</Version>
+		<Version>0.16.5</Version>
 		<PackageReleaseNotes></PackageReleaseNotes>
 
 		<TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>

--- a/Src/GBX.NET/GBX.NET.csproj
+++ b/Src/GBX.NET/GBX.NET.csproj
@@ -11,7 +11,7 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 
-		<Version>0.16.3</Version>
+		<Version>0.16.4</Version>
 		<PackageReleaseNotes></PackageReleaseNotes>
 
 		<TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>

--- a/Src/GBX.NET/GBX.NET.csproj
+++ b/Src/GBX.NET/GBX.NET.csproj
@@ -82,6 +82,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
 		<PackageReference Include="TmEssentials" Version="2.3.0" />
+		<ProjectReference Include="..\..\Generators\GBX.NET.Generators\GBX.NET.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/Src/GBX.NET/GBX.NET.csproj
+++ b/Src/GBX.NET/GBX.NET.csproj
@@ -81,7 +81,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-		<PackageReference Include="TmEssentials" Version="2.3.0" />
+		<PackageReference Include="TmEssentials" Version="2.3.1" />
 		<ProjectReference Include="..\..\Generators\GBX.NET.Generators\GBX.NET.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 

--- a/Src/GBX.NET/GameBoxReader.cs
+++ b/Src/GBX.NET/GameBoxReader.cs
@@ -167,6 +167,8 @@ public class GameBoxReader : BinaryReader
             // Edge-case scenario where Id doesn't have a version for whatever reason (can be multiple)
             if ((gbx.IdVersion & 0xC0000000) > 10)
             {
+                Logger?.LogWarning("The detected Id version is {version}! Make sure this is correct.", gbx.IdVersion);
+
                 gbx.IdVersion = 3;
 
                 if (!BaseStream.CanSeek)

--- a/Src/GBX.NET/LoggerMessageGen.cs
+++ b/Src/GBX.NET/LoggerMessageGen.cs
@@ -11,7 +11,7 @@ internal static partial class LoggerMessageGen
     [LoggerMessage(EventId = 3, Level = LogLevel.Debug, Message = "0x{chunkHex} (???%)")]
     public static partial void LogChunkProgressSeekless(this ILogger logger, string chunkHex);
 
-    [LoggerMessage(EventId = 4, Level = LogLevel.Debug, Message = "0x{chunkHex} [unknown] ({size} bytes)")]
+    [LoggerMessage(EventId = 4, Level = LogLevel.Warning, Message = "0x{chunkHex} [unknown] ({size} bytes)")]
     public static partial void LogChunkUnknownSkippable(this ILogger logger, string chunkHex, int size);
 
     [LoggerMessage(EventId = 5, Level = LogLevel.Debug, Message = "Unexpected end of the stream: {position}/{length}")]

--- a/Src/GBX.NET/Managers/NodeCacheManager.cs
+++ b/Src/GBX.NET/Managers/NodeCacheManager.cs
@@ -409,9 +409,11 @@ public static class NodeCacheManager
             HeaderChunkAttributesById[chunkId] = attributes;
             HeaderChunkTypesById[chunkId] = type;
             HeaderChunkConstructors[chunkId] = constructor;
+
+            return;
         }
 
-        if (type.BaseType?.IsGenericType == true && type.BaseType.GetGenericTypeDefinition() == typeof(SkippableChunk<>))
+        if (type.GetInterface(nameof(ISkippableChunk)) is not null)
         {
             SkippableChunks[type] = 1;
         }

--- a/Tests/GBX.NET.Tests/GBX.NET.Tests.csproj
+++ b/Tests/GBX.NET.Tests/GBX.NET.Tests.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
-		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/Tests/GBX.NET.Tests/GBX.NET.Tests.csproj
+++ b/Tests/GBX.NET.Tests/GBX.NET.Tests.csproj
@@ -11,8 +11,8 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/Tests/GBX.NET.Tests/GBX.NET.Tests.csproj
+++ b/Tests/GBX.NET.Tests/GBX.NET.Tests.csproj
@@ -35,26 +35,17 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\Src\GBX.NET.LZO\GBX.NET.LZO.csproj" />
 		<ProjectReference Include="..\..\Src\GBX.NET\GBX.NET.csproj" />
-		<ProjectReference Include="..\GBX.NET.Tests.Generators\GBX.NET.Tests.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.6.1" Condition="$(TargetFramework.StartsWith('net4')) AND '$(OS)' == 'Unix'" />
+		<ProjectReference Include="..\..\Generators\GBX.NET.Tests.Generators\GBX.NET.Tests.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<Content Include="..\..\ExampleFiles\**">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
-	</ItemGroup>
-
-	<ItemGroup>
-	  <None Remove="TestData\Chunks\CGameCtnChallenge.2019.11.19.1850.zip" />
-	  <None Remove="TestData\Chunks\CGameCtnCollector.2015-06-18_15_10.zip" />
-	  <None Remove="TestData\Chunks\CGameCtnCollector.2016-11-07_16_15.zip" />
-	  <None Remove="TestData\Chunks\CGameCtnMacroBlockInfo.2015-06-18_15_10.zip" />
-	  <None Remove="TestData\Chunks\CGameCtnMacroBlockInfo.2016-11-07_16_15.zip" />
-	  <None Remove="TestData\Chunks\CGameCtnMacroBlockInfo.2022.7.6.1137.zip" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
The library has reached 1MB!
- Added a lot more attributes
- Added `AsHeader` to every class implementing `INodeHeader`
- Added a bit more versioning protection to certain chunks (still not enough though)
- Added `CGameCtnChallenge.BakedClipsAdditionalData` and `CGameCtnChallenge.NbBakedBlocks`
- Added cam-related members to `CGameCtnMediaBlockCameraGame`
- Fixed `CGameCtnChallenge.BakedBlocks` in TM2
- Fixed old collector icon being horizontally flipped
- Fixed `KindInHeader` not pointing at the correct field
- Improved map chunks related to real-time thumbnail cameras
- Attempt to optimize block parse