### PR TITLE
fix TimeOfDay read/write

### DIFF
--- a/Src/GBX.NET/GameBoxReader.cs
+++ b/Src/GBX.NET/GameBoxReader.cs
@@ -415,7 +415,7 @@ public class GameBoxReader : BinaryReader
         var maxTime = TimeSpan.FromDays(1) - TimeSpan.FromTicks(1);
         var maxSecs = maxTime.TotalSeconds;        
         
-        return TimeSpan.FromSeconds(dayTime / (double)ushort.MaxValue * maxSecs);
+        return TimeSpan.FromSeconds(Math.Round(dayTime / (double)ushort.MaxValue * maxSecs, 7));
     }
 
     /// <summary>

--- a/Src/GBX.NET/GameBoxWriter.cs
+++ b/Src/GBX.NET/GameBoxWriter.cs
@@ -225,7 +225,7 @@ public class GameBoxWriter : BinaryWriter
         var maxSecs = maxTime.TotalSeconds;
         var secs = timeOfDay.Value.TotalSeconds % maxTime.TotalSeconds;
 
-        Write((ushort)(secs / maxSecs * ushort.MaxValue));
+        Write((int)(secs / maxSecs * ushort.MaxValue));
     }
 
     /// <exception cref="ArgumentNullException"><paramref name="fileRef"/> is null.</exception>


### PR DESCRIPTION
This PR fixes 2 issues with TimeOfDay reader/writes:
1) write TimeOfDay as `int` instead of `ushort`
2) round seconds before TimeSpan.FromSeconds cause it truncates it to 7 decimal places. To avoid the following:
```
TimeOfDay read value: 33041
TimeOfDay read seconds: 43560.57679097728
TimeOfDay write seconds: 43560.5767909
TimeOfDay write value: 33040
```
