### PR TITLE
GBX.NET 1.0.1

### DIFF
--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -4421,7 +4421,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
                     using var entryDataStream = new MemoryStream();
 
                     entryStream.CopyTo(entryDataStream);
-                    n.embeddedData[entry.Name] = entryDataStream.ToArray();
+                    n.embeddedData[entry.FullName] = entryDataStream.ToArray();
                 }
             }
 

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -2610,7 +2610,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     [Chunk(0x03043008, "author")]
     public class Chunk03043008 : HeaderChunk<CGameCtnChallenge>, IVersionable
     {
-        private int version;
+        private int version = 1;
 
         /// <summary>
         /// Version of the chunk.

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -4,24 +4,30 @@ public partial class CGameCtnGhost
 {
     public class PlayerInputData : IReadableWritable
     {
-        public int U01; // 8 in shootmania, 12 in tm2020
-        public int U02;
-        public int U03 = -1;
-        public int U04;
-        public byte[]? U05;
-        
+        private int u01; // 8 in shootmania, 12 in tm2020
+        private int u02;
+        private int u03 = -1;
+        private int u04;
+        private byte[]? u05;
+
+        public int U01 { get => u01; set => u01 = value; }
+        public int U02 { get => u02; set => u02 = value; }
+        public int U03 { get => u03; set => u03 = value; }
+        public int U04 { get => u04; set => u04 = value; }
+        public byte[]? U05 { get => u05; set => u05 = value; }
+
         public void ReadWrite(GameBoxReaderWriter rw, int version = 0)
         {
-            rw.Int32(ref U01); // 8 in shootmania, 12 in tm2020
-            rw.Int32(ref U02);
+            rw.Int32(ref u01); // 8 in shootmania, 12 in tm2020
+            rw.Int32(ref u02);
             
             if (version >= 4)
             {
-                rw.Int32(ref U03);
+                rw.Int32(ref u03);
             }
             
-            rw.Int32(ref U04);
-            rw.Bytes(ref U05);
+            rw.Int32(ref u04);
+            rw.Bytes(ref u05);
         }
     }
 }

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.cs
@@ -918,19 +918,17 @@ public partial class CGameCtnGhost : CGameGhost
 
     #endregion
 
-    #region 0x015 chunk (vehicle)
+    #region 0x015 chunk (ghost nickname)
 
     /// <summary>
-    /// CGameCtnGhost 0x015 chunk
+    /// CGameCtnGhost 0x015 chunk (ghost nickname)
     /// </summary>
-    [Chunk(0x03092015)]
+    [Chunk(0x03092015, "ghost nickname")]
     public class Chunk03092015 : Chunk<CGameCtnGhost>
     {
-        public string? U01;
-
         public override void ReadWrite(CGameCtnGhost n, GameBoxReaderWriter rw)
         {
-            rw.Id(ref U01);
+            rw.Id(ref n.ghostNickname);
         }
     }
 

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.cs
@@ -89,6 +89,7 @@ public partial class CGameCtnGhost : CGameGhost
     [AppliedWithChunk(typeof(Chunk03092003))]
     [AppliedWithChunk(typeof(Chunk03092006))]
     [AppliedWithChunk(typeof(Chunk0309200D))]
+    [AppliedWithChunk(typeof(Chunk03092015))]
     [AppliedWithChunk(typeof(Chunk03092017))]
     public string? GhostNickname
     {

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.cs
@@ -403,7 +403,19 @@ public partial class CGameCtnGhost : CGameGhost
     /// </summary>
     [NodeMember]
     [AppliedWithChunk(typeof(Chunk0309201D))]
-    public PlayerInputData[]? PlayerInputs { get => playerInputs; set => playerInputs = value; }
+    public PlayerInputData[]? PlayerInputs
+    {
+        get
+        {
+            DiscoverChunk<Chunk0309201D>();
+            return playerInputs;
+        }
+        set
+        {
+            DiscoverChunk<Chunk0309201D>();
+            playerInputs = value;
+        }
+    }
 
     #endregion
 

--- a/Src/GBX.NET/GBX.NET.csproj
+++ b/Src/GBX.NET/GBX.NET.csproj
@@ -11,7 +11,7 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 
-		<Version>1.0.0</Version>
+		<Version>1.0.1</Version>
 		<PackageReleaseNotes></PackageReleaseNotes>
 
 		<TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>

--- a/Tools/GbxExplorer/Client/GbxExplorer.Client.csproj
+++ b/Tools/GbxExplorer/Client/GbxExplorer.Client.csproj
@@ -7,7 +7,7 @@
 		<ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
 		<NullabilityInfoContextSupport>true</NullabilityInfoContextSupport>
 		<BlazorEnableTimeZoneSupport>false</BlazorEnableTimeZoneSupport>
-		<Version>1.0.0</Version>
+		<Version>1.0.1</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Tools/GbxExplorer/Client/Sections/SectionSaveGbx.razor
+++ b/Tools/GbxExplorer/Client/Sections/SectionSaveGbx.razor
@@ -57,7 +57,7 @@
 
                 @if (extensions is not null)
                 {
-                    if (selectedSaveMethod == 1)
+                    if (selectedSaveMethod == 1 && !extensions.Contains(customExtension))
                     {
                         customExtension = extensions.FirstOrDefault() ?? "";
                     }


### PR DESCRIPTION
- Fixed embedded object writing (thx nbert)
- Fixed `PlayerInputs` not properly loading
- Resolved `CGameCtnGhost` `0x015`
- `CGameCtnChallenge` `0x008` version now defaults to 1

**GBX.NET Explorer**
- Fixed **Export selected node to Gbx** not allowing to change extension