### PR TITLE
GBX.NET 1.1.1

### DIFF
--- a/.github/workflows/deploy-gbxexplorer-pages.yml
+++ b/.github/workflows/deploy-gbxexplorer-pages.yml
@@ -81,12 +81,6 @@ jobs:
         uses: actions/download-artifact@v3.0.0
         with:
           name: app
-          
-      - name: Download docs artifact
-        uses: actions/download-artifact@v3.0.0
-        with:
-          name: docs
-          path: docs
         
       - name: Setup Pages
         uses: actions/configure-pages@v2

--- a/.github/workflows/deploy-gbxexplorer-pages.yml
+++ b/.github/workflows/deploy-gbxexplorer-pages.yml
@@ -66,51 +66,9 @@ jobs:
           name: app
           path: publish/wwwroot
           retention-days: 1
-          
-  build-docs:
-  
-    runs-on: ubuntu-latest
-    
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          
-      - name: Clone wiki
-        run: |
-          git clone https://github.com/BigBang1112/gbx-net.wiki.git wiki
-          cp -r wiki/* Docs/wiki
-        
-      - name: Create global.json
-        uses: 1arp/create-a-file-action@0.2
-        with:
-          path: Docs
-          file: global.json
-          content: |
-            {
-              "_gitContribute": {
-                "repo": "https://github.com/BigBang1112/gbx-net",
-                "branch": "${{ github.ref_name }}"
-              }
-            }
-  
-      - name: Generate docs
-        uses: nikeee/docfx-action@v1.0.0
-        with:
-          args: Docs/docfx.json --globalMetadataFiles global.json
-      
-      - name: Copy docs to root
-        run: cp -r Docs/_site docs
-
-      - name: Upload docs artifact
-        uses: actions/upload-artifact@v3.1.0
-        with:
-          name: docs
-          path: docs
-          retention-days: 1
   
   deploy:
-    needs: [build-gbxexplorer, build-docs]
+    needs: build-gbxexplorer
   
     environment:
       name: github-pages

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Here are some of the useful classes/types to start with:
 - Current C# language version is **11**.
 
 To build the solution:
-- Installing Visual Studio 2022 with default .NET tools, **.NET WebAssembly Build Tools**, and **.NET Framework 4.6.2 Targeting Pack** is the easiest option.
+- Installing Visual Studio 2022 with default .NET tools, **.NET WebAssembly Build Tools**, **.NET Core 3.1 Runtime**, and **.NET Framework 4.6.2 Targeting Pack** is the easiest option.
 - JetBrains Rider also works as it should. Visual Studio Code may work with a bit more setup.
 - Make sure you have all the needed targetting packs installed (currently **.NET 7.0**, .NET 6.0, .NET Standard 2.1, .NET Standard 2.0, and .NET Framework 4.6.2).
 

--- a/Samples/BlocksAndTheirClipsTM2020/Program.cs
+++ b/Samples/BlocksAndTheirClipsTM2020/Program.cs
@@ -32,7 +32,7 @@ foreach (var blockInfoFile in Directory.EnumerateFiles(blockFolder, "*.*", Searc
             Ground = CreateVariant(blockInfo.VariantBaseGround)
         };
 
-        dict.Add(blockInfo.Author.Id, block);
+        dict.Add(blockInfo.Ident.Id, block);
     }
     catch (NotAGbxException)
     {

--- a/Src/GBX.NET.PAK/GBX.NET.PAK.csproj
+++ b/Src/GBX.NET.PAK/GBX.NET.PAK.csproj
@@ -13,7 +13,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		
-		<Version>1.1.1</Version>
+		<Version>1.1.2</Version>
 		<PackageReleaseNotes></PackageReleaseNotes>
 		
 		<TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>

--- a/Src/GBX.NET.PAK/NadeoPakFile.cs
+++ b/Src/GBX.NET.PAK/NadeoPakFile.cs
@@ -181,26 +181,40 @@ public class NadeoPakFile
 
     public string GetFullFileName()
     {
-        if (Folder == null) return Name;
-
-        var currentParent = Folder;
-        var folders = new List<string>
-        {
-            Name
-        };
-
-        while (currentParent != null)
-        {
-            folders.Insert(0, currentParent.Name);
-            currentParent = currentParent.Parent;
-        }
-
-        return Path.Combine(folders.ToArray());
+        return Path.Combine(GetDirectoryName(), Name);
     }
 
-    public string? GetFullDirectoryName()
+    /// <summary>
+    /// Gets the directory name (relative to the PAK file), also including directories in <see cref="Name"/>.
+    /// </summary>
+    /// <returns>A full directory name.</returns>
+    public string GetFullDirectoryName()
     {
-        return Path.GetDirectoryName(GetFullFileName());
+        return Path.GetDirectoryName(GetFullFileName()) ?? "";
+    }
+
+    /// <summary>
+    /// Gets the directory name (relative to the PAK file), not part of the <see cref="Name"/> itself.
+    /// </summary>
+    /// <returns></returns>
+    public string GetDirectoryName()
+    {
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+        return string.Join(Path.DirectorySeparatorChar, GetParentDirectories().Reverse());
+#else
+        return Path.Combine(GetParentDirectories().Reverse().ToArray());
+#endif
+    }
+
+    private IEnumerable<string> GetParentDirectories()
+    {
+        var currentParent = Folder;
+        
+        while (currentParent is not null)
+        {
+            yield return currentParent.Name;
+            currentParent = currentParent.Parent;
+        }
     }
 
     public string GetFileName()

--- a/Src/GBX.NET/BitReader.cs
+++ b/Src/GBX.NET/BitReader.cs
@@ -1,0 +1,67 @@
+﻿namespace GBX.NET;
+
+public class BitReader
+{
+    private readonly byte[] data;
+
+    public int Position { get; private set; }
+    public int Length { get; }
+
+    public BitReader(byte[] data)
+    {
+        this.data = data;
+
+        Length = data.Length * 8;
+    }
+
+    public bool ReadBit()
+    {
+        var result = (data[Position / 8] & (1 << (Position % 8))) != 0;
+        Position++;
+        return result;
+    }
+
+    public ulong ReadNumber(int bits)
+    {
+        ulong result = 0;
+        for (var i = 0; i < bits; i++)
+            result |= (ulong)(ReadBit() ? 1 : 0) << i;
+        return result;
+    }
+
+    public byte Read2Bit()
+    {
+        return (byte)ReadNumber(bits: 2);
+    }
+
+    public byte ReadByte()
+    {
+        return (byte)ReadNumber(bits: 8);
+    }
+
+    public sbyte ReadSByte()
+    {
+        return (sbyte)ReadNumber(bits: 8);
+    }
+
+    public short ReadInt16()
+    {
+        return (short)ReadNumber(bits: 16);
+    }
+
+    public int ReadInt32()
+    {
+        return (int)ReadNumber(bits: 32);
+    }
+
+    // ReadToEnd through bits
+
+    public byte[] ReadToEnd()
+    {
+        var remaining = Length - Position;
+        var result = new byte[(remaining + 7) / 8];
+        for (var i = 0; i < remaining; i++)
+            result[i / 8] |= (byte)((ReadBit() ? 1 : 0) << (i % 8));
+        return result;
+    }
+}

--- a/Src/GBX.NET/BitReader.cs
+++ b/Src/GBX.NET/BitReader.cs
@@ -60,6 +60,11 @@ public class BitReader
         return (short)ReadNumber(bits: 16);
     }
 
+    public ushort ReadUInt16()
+    {
+        return (ushort)ReadNumber(bits: 16);
+    }
+
     public int ReadInt32()
     {
         return (int)ReadNumber(bits: 32);

--- a/Src/GBX.NET/BitReader.cs
+++ b/Src/GBX.NET/BitReader.cs
@@ -14,23 +14,27 @@ public class BitReader
         Length = data.Length * 8;
     }
 
-    public bool ReadBit()
+    private bool ReadBit(ReadOnlySpan<byte> data)
     {
         var result = (data[Position / 8] & (1 << (Position % 8))) != 0;
         Position++;
         return result;
     }
 
+    public bool ReadBit()
+    {
+        return ReadBit(data);
+    }
+
     public ulong ReadNumber(int bits)
     {
         ulong result = 0;
 
-        var dataSpan = data.AsSpan();
-        
+        ReadOnlySpan<byte> dataSpan = data;
+
         for (var i = 0; i < bits; i++)
         {
-            result |= (ulong)(dataSpan[Position / 8] & (1 << (Position % 8))) << i;
-            Position++;
+            result |= (ulong)(ReadBit(dataSpan) ? 1 : 0) << i;
         }
         
         return result;

--- a/Src/GBX.NET/BitReader.cs
+++ b/Src/GBX.NET/BitReader.cs
@@ -24,8 +24,15 @@ public class BitReader
     public ulong ReadNumber(int bits)
     {
         ulong result = 0;
+
+        var dataSpan = data.AsSpan();
+        
         for (var i = 0; i < bits; i++)
-            result |= (ulong)(ReadBit() ? 1 : 0) << i;
+        {
+            result |= (ulong)(dataSpan[Position / 8] & (1 << (Position % 8))) << i;
+            Position++;
+        }
+        
         return result;
     }
 

--- a/Src/GBX.NET/Builders/Engines/Game/CGameCtnMediaBlockTriangles3DBuilder.TMUF.cs
+++ b/Src/GBX.NET/Builders/Engines/Game/CGameCtnMediaBlockTriangles3DBuilder.TMUF.cs
@@ -1,0 +1,23 @@
+﻿namespace GBX.NET.Builders.Engines.Game;
+
+public partial class CGameCtnMediaBlockTriangles3DBuilder
+{
+    public class TMUF : GameBuilder<CGameCtnMediaBlockTriangles3DBuilder, CGameCtnMediaBlockTriangles3D>
+    {
+        public IList<CGameCtnMediaBlockTriangles.Key>? Keys { get; set; }
+        
+        public TMUF(CGameCtnMediaBlockTriangles3DBuilder baseBuilder, CGameCtnMediaBlockTriangles3D node) : base(baseBuilder, node) { }
+
+        public TMUF WithKeys(Func<CGameCtnMediaBlockTriangles3D, IList<CGameCtnMediaBlockTriangles.Key>> keys)
+        {
+            Keys = keys(Node);
+            return this;
+        }
+
+        public override CGameCtnMediaBlockTriangles3D Build()
+        {
+            Node.Keys = Keys ?? new List<CGameCtnMediaBlockTriangles.Key>();
+            return Node;
+        }
+    }
+}

--- a/Src/GBX.NET/Builders/Engines/Game/CGameCtnMediaBlockTriangles3DBuilder.cs
+++ b/Src/GBX.NET/Builders/Engines/Game/CGameCtnMediaBlockTriangles3DBuilder.cs
@@ -1,0 +1,34 @@
+﻿namespace GBX.NET.Builders.Engines.Game;
+
+public partial class CGameCtnMediaBlockTriangles3DBuilder : Builder
+{
+    public Vec4[] Vertices { get; }
+    public Int3[]? Triangles { get; set; }
+    
+    /// <param name="vertices">Array of vertex colors.</param>
+    public CGameCtnMediaBlockTriangles3DBuilder(Vec4[] vertices)
+    {
+        Vertices = vertices;
+    }
+
+    public CGameCtnMediaBlockTriangles3DBuilder WithTriangles(Int3[] triangles)
+    {
+        Triangles = triangles;
+        return this;
+    }
+
+    public TMUF ForTMUF() => new(this, NewNode());
+
+    internal CGameCtnMediaBlockTriangles3D NewNode()
+    {
+        var node = new CGameCtnMediaBlockTriangles3D
+        {
+            Vertices = Vertices,
+            Triangles = Triangles ?? Array.Empty<Int3>()
+        };
+        
+        node.CreateChunk<CGameCtnMediaBlockTriangles.Chunk03029001>();
+        
+        return node;
+    }
+}

--- a/Src/GBX.NET/Engines/Control/CControlEffectSimi.Key.cs
+++ b/Src/GBX.NET/Engines/Control/CControlEffectSimi.Key.cs
@@ -41,18 +41,28 @@ public partial class CControlEffectSimi
         {
             base.ReadWrite(rw, version);
 
+            // GmSimi2::Archive
             rw.Vec2(ref position);
             rw.Single(ref rotation);
             rw.Vec2(ref scale);
-            rw.Single(ref opacity);
-            rw.Single(ref depth);
+            //
 
-            if (version != 2)
+            if (version >= 1)
             {
-                rw.Single(ref U01);
-                rw.Single(ref isContinuousEffect);
-                rw.Single(ref U02);
-                rw.Single(ref U03);
+                rw.Single(ref opacity);
+
+                if (version >= 2)
+                {
+                    rw.Single(ref depth);
+
+                    if (version >= 3)
+                    {
+                        rw.Single(ref U01);
+                        rw.Single(ref isContinuousEffect);
+                        rw.Single(ref U02);
+                        rw.Single(ref U03);
+                    }
+                }
             }
         }
     }

--- a/Src/GBX.NET/Engines/Control/CControlEffectSimi.cs
+++ b/Src/GBX.NET/Engines/Control/CControlEffectSimi.cs
@@ -89,6 +89,23 @@ public partial class CControlEffectSimi : CControlEffect, CGameCtnMediaBlock.IHa
 
     #region Chunks
 
+    #region 0x001 chunk
+
+    /// <summary>
+    /// CControlEffectSimi 0x001 chunk
+    /// </summary>
+    [Chunk(0x07010001)]
+    public class Chunk07010001 : Chunk<CControlEffectSimi>
+    {
+        public override void ReadWrite(CControlEffectSimi n, GameBoxReaderWriter rw)
+        {
+            rw.List<Key>(ref n.keys!, (rw, x) => x.ReadWrite(rw, version: 1));
+            rw.Boolean(ref n.centered);
+        }
+    }
+
+    #endregion
+
     #region 0x002 chunk
 
     /// <summary>

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -4470,14 +4470,14 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
             {
                 var gbxItem = item.GetGbx() ?? throw new ThisShouldNotHappenException();
 
-                if (item.Author is null)
+                if (item.Ident is null)
                 {
                     continue;
                 }
 
                 if (gbxItem.FileName is null)
                 {
-                    embedded.Add(item.Author);
+                    embedded.Add(item.Ident);
                     continue;
                 }
 
@@ -4494,7 +4494,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
                     }
                 }
 
-                embedded.Add(item.Author with { Id = id });
+                embedded.Add(item.Ident with { Id = id });
             }
 
             writer.WriteList(embedded, (x, w) => w.Write(x));

--- a/Src/GBX.NET/Engines/Game/CGameCtnDecorationSize.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnDecorationSize.cs
@@ -6,6 +6,7 @@ public class CGameCtnDecorationSize : CMwNod
     private Vec2 editionZoneMin;
     private Vec2 editionZoneMax;
     private int baseHeightBase;
+    private Int3 size;
     private CSceneLayout? scene;
     private GameBoxRefTable.File? sceneFile;
 
@@ -20,6 +21,10 @@ public class CGameCtnDecorationSize : CMwNod
     [NodeMember(ExactlyNamed = true)]
     [AppliedWithChunk<Chunk0303B001>]
     public int BaseHeightBase { get => baseHeightBase; set => baseHeightBase = value; }
+
+    [NodeMember]
+    [AppliedWithChunk<Chunk0303B001>]
+    public Int3 Size { get => size; set => size = value; }
 
     [NodeMember(ExactlyNamed = true)]
     [AppliedWithChunk<Chunk0303B001>]
@@ -62,16 +67,10 @@ public class CGameCtnDecorationSize : CMwNod
     [Chunk(0x0303B001)]
     public class Chunk0303B001 : Chunk<CGameCtnDecorationSize>
     {
-        public int U01;
-        public int U02;
-        public int U03;
-
         public override void ReadWrite(CGameCtnDecorationSize n, GameBoxReaderWriter rw)
         {
             rw.Int32(ref n.baseHeightBase);
-            rw.Int32(ref U01);
-            rw.Int32(ref U02);
-            rw.Int32(ref U03);
+            rw.Int3(ref n.size);
             rw.NodeRef<CSceneLayout>(ref n.scene, ref n.sceneFile);
         }
     }

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -45,6 +45,22 @@ public partial class CGameCtnGhost
                         ? ProcessShootmaniaInputs()
                         : ProcessTrackmaniaInputs();
 
+#if DEBUG
+                    var testList = new List<IInputChange>();
+
+                    try
+                    {
+                        foreach (var input in inputEnumerable)
+                        {
+                            testList.Add(input);
+                        }
+                    }
+                    catch
+                    {
+
+                    }
+#endif
+
                     inputChanges = inputEnumerable.ToArray();
                 }
 
@@ -149,6 +165,8 @@ public partial class CGameCtnGhost
         {
             var r = new BitReader(data);
 
+            var started = false;
+
             for (var i = 0; i < ticks; i++)
             {
                 var different = false;
@@ -170,6 +188,11 @@ public partial class CGameCtnGhost
                         ? r.Read2Bit()
                         : r.ReadNumber(bits: version is EVersion._2020_04_08 ? 33 : 34);
 
+                    if (!started)
+                    {
+                        started = (states & 2) != 0;
+                    }
+                    
                     different = true;
                 }
 
@@ -188,7 +211,12 @@ public partial class CGameCtnGhost
                 // If mouse is not plugged, it is also included
                 // In code, this check is presented as '(X - 2 & 0xfffffffd) == 0'
 
-                if (states.HasValue || i > 0)
+                if (r.Position < r.Length)
+                {
+                    yield break;
+                }
+
+                if (started)
                 {
                     var sameValue = r.ReadBit();
 

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -188,7 +188,7 @@ public partial class CGameCtnGhost
                 // If mouse is not plugged, it is also included
                 // In code, this check is presented as '(X - 2 & 0xfffffffd) == 0'
 
-                if (states.HasValue || i > 1)
+                if (states.HasValue || i > 0)
                 {
                     var sameValue = r.ReadBit();
 

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -178,56 +178,58 @@ public partial class CGameCtnGhost
                 var gas = default(bool?);
                 var brake = default(bool?);
 
-                var sameState = r.ReadBit();
-
-                if (!sameState)
+                try
                 {
-                    var onlySomething = r.ReadBit();
+                    var sameState = r.ReadBit();
 
-                    states = onlySomething
-                        ? r.Read2Bit()
-                        : r.ReadNumber(bits: version is EVersion._2020_04_08 ? 33 : 34);
-
-                    if (!started)
+                    if (!sameState)
                     {
-                        started = (states & 2) != 0;
-                    }
-                    
-                    different = true;
-                }
+                        var onlySomething = r.ReadBit();
 
-                var sameMouse = r.ReadBit();
+                        states = onlySomething
+                            ? r.Read2Bit()
+                            : r.ReadNumber(bits: version is EVersion._2020_04_08 ? 33 : 34);
 
-                if (!sameMouse)
-                {
-                    mouseAccuX = r.ReadInt16();
-                    mouseAccuY = r.ReadInt16();
-
-                    different = true;
-                }
-
-                // This check is a bit weird, may not work for StormMan gameplay
-                // If starting with horn on, it is included on first tick
-                // If mouse is not plugged, it is also included
-                // In code, this check is presented as '(X - 2 & 0xfffffffd) == 0'
-
-                if (r.Position < r.Length)
-                {
-                    yield break;
-                }
-
-                if (started)
-                {
-                    var sameValue = r.ReadBit();
-
-                    if (!sameValue)
-                    {
-                        steer = r.ReadSByte();
-                        gas = r.ReadBit();
-                        brake = r.ReadBit();
+                        if (!started)
+                        {
+                            started = (states & 2) != 0;
+                        }
 
                         different = true;
                     }
+
+                    var sameMouse = r.ReadBit();
+
+                    if (!sameMouse)
+                    {
+                        mouseAccuX = r.ReadInt16();
+                        mouseAccuY = r.ReadInt16();
+
+                        different = true;
+                    }
+
+                    // This check is a bit weird, may not work for StormMan gameplay
+                    // If starting with horn on, it is included on first tick
+                    // If mouse is not plugged, it is also included
+                    // In code, this check is presented as '(X - 2 & 0xfffffffd) == 0'
+
+                    if (started)
+                    {
+                        var sameValue = r.ReadBit();
+
+                        if (!sameValue)
+                        {
+                            steer = r.ReadSByte();
+                            gas = r.ReadBit();
+                            brake = r.ReadBit();
+
+                            different = true;
+                        }
+                    }
+                }
+                catch (IndexOutOfRangeException)
+                {
+                    
                 }
 
                 if (different)
@@ -270,7 +272,7 @@ public partial class CGameCtnGhost
             TimeInt32 Timestamp { get; }
         }
 
-        public record struct ShootmaniaInputChange(int Tick,
+        public readonly record struct ShootmaniaInputChange(int Tick,
                                                    short? MouseAccuX,
                                                    short? MouseAccuY,
                                                    EStrafe? Strafe,
@@ -299,7 +301,7 @@ public partial class CGameCtnGhost
             ulong? IInputChange.States => States is null ? null : (ulong)States;
         }
 
-        public record struct TrackmaniaInputChange(int Tick,
+        public readonly record struct TrackmaniaInputChange(int Tick,
                                                    ulong? States,
                                                    short? MouseAccuX,
                                                    short? MouseAccuY,

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -273,12 +273,12 @@ public partial class CGameCtnGhost
         }
 
         public readonly record struct ShootmaniaInputChange(int Tick,
-                                                   short? MouseAccuX,
-                                                   short? MouseAccuY,
-                                                   EStrafe? Strafe,
-                                                   EWalk? Walk,
-                                                   byte? Vertical,
-                                                   int? States) : IInputChange
+                                                            short? MouseAccuX,
+                                                            short? MouseAccuY,
+                                                            EStrafe? Strafe,
+                                                            EWalk? Walk,
+                                                            byte? Vertical,
+                                                            int? States) : IInputChange
         {
             public TimeInt32 Timestamp => new(Tick * 10);
 
@@ -302,17 +302,33 @@ public partial class CGameCtnGhost
         }
 
         public readonly record struct TrackmaniaInputChange(int Tick,
-                                                   ulong? States,
-                                                   short? MouseAccuX,
-                                                   short? MouseAccuY,
-                                                   sbyte? Steer,
-                                                   bool? Gas,
-                                                   bool? Brake) : IInputChange
+                                                            ulong? States,
+                                                            short? MouseAccuX,
+                                                            short? MouseAccuY,
+                                                            sbyte? Steer,
+                                                            bool? Gas,
+                                                            bool? Brake) : IInputChange
         {
             public TimeInt32 Timestamp { get; } = new(Tick * 10);
 
             public bool? Respawn => States is null ? null : (States & 2147483648) != 0;
-            public bool? Horn => null;
+            public bool? Horn
+            {
+                get
+                {
+                    if (States is null)
+                    {
+                        return null;
+                    }
+                    
+                    if (Tick < 2)
+                    {
+                        return null; // TODO
+                    }
+                    
+                    return (States & 2) != 0;
+                }
+            }
         }
     }
 }

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -188,7 +188,7 @@ public partial class CGameCtnGhost
                 // If mouse is not plugged, it is also included
                 // In code, this check is presented as '(X - 2 & 0xfffffffd) == 0'
 
-                if (states.HasValue || i > 0)
+                if (states.HasValue || i > 1)
                 {
                     var sameValue = r.ReadBit();
 

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -268,6 +268,8 @@ public partial class CGameCtnGhost
             ushort? MouseAccuX { get; }
             ushort? MouseAccuY { get; }
             ulong? States { get; }
+            bool? Respawn { get; }
+            bool? Horn { get; }
 
             TimeInt32 Timestamp { get; }
         }

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -326,7 +326,7 @@ public partial class CGameCtnGhost
                         return null; // TODO
                     }
                     
-                    return (States & 2) != 0;
+                    return States == 2;
                 }
             }
         }

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -90,8 +90,8 @@ public partial class CGameCtnGhost
             {
                 var different = false;
 
-                var mouseAccuX = default(short?);
-                var mouseAccuY = default(short?);
+                var mouseAccuX = default(ushort?);
+                var mouseAccuY = default(ushort?);
                 var strafe = default(EStrafe?);
                 var walk = default(EWalk?);
                 var vertical = default(byte?);
@@ -101,8 +101,8 @@ public partial class CGameCtnGhost
 
                 if (!sameMouse)
                 {
-                    mouseAccuX = r.ReadInt16();
-                    mouseAccuY = r.ReadInt16();
+                    mouseAccuX = r.ReadUInt16();
+                    mouseAccuY = r.ReadUInt16();
 
                     different = true;
                 }
@@ -172,8 +172,8 @@ public partial class CGameCtnGhost
                 var different = false;
 
                 var states = default(ulong?);
-                var mouseAccuX = default(short?);
-                var mouseAccuY = default(short?);
+                var mouseAccuX = default(ushort?);
+                var mouseAccuY = default(ushort?);
                 var steer = default(sbyte?);
                 var gas = default(bool?);
                 var brake = default(bool?);
@@ -202,8 +202,8 @@ public partial class CGameCtnGhost
 
                     if (!sameMouse)
                     {
-                        mouseAccuX = r.ReadInt16();
-                        mouseAccuY = r.ReadInt16();
+                        mouseAccuX = r.ReadUInt16();
+                        mouseAccuY = r.ReadUInt16();
 
                         different = true;
                     }
@@ -229,7 +229,7 @@ public partial class CGameCtnGhost
                 }
                 catch (IndexOutOfRangeException)
                 {
-                    
+
                 }
 
                 if (different)
@@ -265,16 +265,16 @@ public partial class CGameCtnGhost
         public interface IInputChange
         {
             int Tick { get; }
-            short? MouseAccuX { get; }
-            short? MouseAccuY { get; }
+            ushort? MouseAccuX { get; }
+            ushort? MouseAccuY { get; }
             ulong? States { get; }
 
             TimeInt32 Timestamp { get; }
         }
 
         public readonly record struct ShootmaniaInputChange(int Tick,
-                                                            short? MouseAccuX,
-                                                            short? MouseAccuY,
+                                                            ushort? MouseAccuX,
+                                                            ushort? MouseAccuY,
                                                             EStrafe? Strafe,
                                                             EWalk? Walk,
                                                             byte? Vertical,
@@ -303,8 +303,8 @@ public partial class CGameCtnGhost
 
         public readonly record struct TrackmaniaInputChange(int Tick,
                                                             ulong? States,
-                                                            short? MouseAccuX,
-                                                            short? MouseAccuY,
+                                                            ushort? MouseAccuX,
+                                                            ushort? MouseAccuY,
                                                             sbyte? Steer,
                                                             bool? Gas,
                                                             bool? Brake) : IInputChange
@@ -320,12 +320,12 @@ public partial class CGameCtnGhost
                     {
                         return null;
                     }
-                    
+
                     if (Tick < 2)
                     {
                         return null; // TODO
                     }
-                    
+
                     return States == 2;
                 }
             }

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -1,11 +1,9 @@
-﻿using System.Collections;
-using System.Text;
-
-namespace GBX.NET.Engines.Game;
+﻿namespace GBX.NET.Engines.Game;
 
 //
 // Massive thanks to Mystixor and Shweetz for many of the findings!!!
 // Without these guys, this would've stayed a mystery.
+// Even though the solution was read out of the game code in the end, they gave the important hint.
 //
 
 public partial class CGameCtnGhost
@@ -13,7 +11,6 @@ public partial class CGameCtnGhost
     /// <summary>
     /// Set of inputs.
     /// </summary>
-    /// <remarks>Massive thanks to Mystixor and Shweetz for many of the findings!!!</remarks>
     public class PlayerInputData : IReadableWritable
     {
         public enum EVersion
@@ -28,14 +25,32 @@ public partial class CGameCtnGhost
         private int u02;
         private TimeInt32? startOffset;
         private int ticks;
-        private byte[]? data;
+        private byte[] data = Array.Empty<byte>();
+
+        private IList<IInputChange>? inputChanges;
 
         public EVersion Version { get => version; set => version = value; }
         public int U02 { get => u02; set => u02 = value; }
         public TimeInt32? StartOffset { get => startOffset; set => startOffset = value; }
         public int Ticks { get => ticks; set => ticks = value; }
-        public byte[]? Data { get => data; set => data = value; }
-        public IList<InputChange> InputChanges { get; set; } = Array.Empty<InputChange>();
+        public byte[] Data { get => data; set => data = value; }
+
+        public IList<IInputChange> InputChanges
+        {
+            get
+            {
+                if (inputChanges is null)
+                {
+                    var inputEnumerable = version is <= EVersion._2017_09_12
+                        ? ProcessShootmaniaInputs()
+                        : ProcessTrackmaniaInputs();
+
+                    inputChanges = inputEnumerable.ToArray();
+                }
+
+                return inputChanges;
+            }
+        }
 
         public void ReadWrite(GameBoxReaderWriter rw, int version = 0)
         {
@@ -48,149 +63,226 @@ public partial class CGameCtnGhost
             }
 
             rw.Int32(ref ticks);
-            rw.Bytes(ref data);
-
-            if (rw.Reader is null || data is null)
-            {
-                return;
-            }
-
-            InputChanges = new List<InputChange>();
-
-            try
-            {
-                foreach (var inputChange in ProcessInputs(data, ticks))
-                {
-                    InputChanges.Add(inputChange);
-                }
-            }
-            catch (Exception ex)
-            {
-                rw.Reader.Logger?.LogWarning(ex, "Error while reading inputs!");
-            }
+            rw.Bytes(ref data!);
         }
 
-        internal static IEnumerable<InputChange> ProcessInputs(byte[] data, int ticks)
+        internal IEnumerable<IInputChange> ProcessShootmaniaInputs()
         {
-            var bits = new BitArray(data);
-
-            /*var builder = new StringBuilder();
-            for (var i = 0; i < bits.Length; i++)
-            {
-                if (i != 0 && i % 8 == 0)
-                {
-                    builder.Append(' ');
-                }
-                if (i != 0 && i % 32 == 0)
-                {
-                    builder.AppendLine();
-                }
-                builder.Append(bits[i] ? "1" : "0");
-            }
-            Console.WriteLine(builder.ToString());*/
-
-            var position = 0;
+            var r = new BitReader(data);
 
             for (var i = 0; i < ticks; i++)
             {
-                var somethingHasChanged = true;
-                var hasSteer = false;
-                var steer = default(sbyte);
-                var gas = default(bool?);
-                var brake = default(bool?);
-                var horn = default(bool?);
-                var isRespawn = false;
-                var zeroBitSet = false;
+                var different = false;
 
-                for (var bit = 0; bit < 13; bit++)
+                var mouseAccuX = default(short?);
+                var mouseAccuY = default(short?);
+                var strafe = default(EStrafe?);
+                var walk = default(EWalk?);
+                var vertical = default(byte?);
+                var states = default(int?);
+
+                var sameMouse = r.ReadBit();
+
+                if (!sameMouse)
                 {
-                    if (position >= bits.Length) // Happens often with padding > 0, dunno why
+                    mouseAccuX = r.ReadInt16();
+                    mouseAccuY = r.ReadInt16();
+
+                    different = true;
+                }
+
+                var sameValuesAfter = r.ReadBit();
+                var sameValue = sameValuesAfter;
+
+                if (!sameValuesAfter)
+                {
+                    sameValue = r.ReadBit();
+                }
+
+                if (!sameValue)
+                {
+                    strafe = (EStrafe)r.Read2Bit();
+                    if (strafe == EStrafe.Corrupted) throw new Exception("Corrupted inputs. (strafe == 2)");
+
+                    walk = (EWalk)r.Read2Bit();
+                    if (walk == EWalk.Corrupted) throw new Exception("Corrupted inputs. (walk == 2)");
+
+                    if (version == EVersion._2017_09_12)
                     {
-                        break;
+                        vertical = r.Read2Bit();
                     }
 
-                    var bitSet = bits.Get(position);
-                    position++;
+                    different = true;
+                }
 
-                    if (bit == 0)
+                if (!sameValuesAfter)
+                {
+                    sameValue = r.ReadBit();
+
+                    if (!sameValue)
                     {
-                        zeroBitSet = bitSet;
-                        
-                        if (zeroBitSet)
-                        {
-                            continue;
-                        }
+                        var onlyTriggerAndAction = r.ReadBit();
 
-                        var isHorn = bits.Get(position);
-                        var isMouse = isHorn && bits.Get(position); // mouse indicates 11 after the zero bit
+                        states = onlyTriggerAndAction
+                            ? r.Read2Bit()
+                            : r.ReadInt32();
 
-                        if (isMouse)
-                        {
-                            position += 31;
-                            break;
-                        }
-
-                        isRespawn = !isHorn;
-                        var isRespawnHorn = isRespawn && position + 7 <= bits.Count && bits.Get(position + 7);
-
-                        if (isRespawnHorn)
-                        {
-                            horn = true;
-                        }
-                        else if (isHorn)
-                        {
-                            horn = bits.Get(position + 2);
-                        }
-
-                        position += isHorn ? 3 : 35;
-                        break;
-                    }
-                    else if (bit == 1 && bitSet && zeroBitSet)
-                    {
-                        somethingHasChanged = false;
-                        
-                        var goToNextTick = bits.Get(position);
-
-                        if (goToNextTick)
-                        {
-                            position++;
-                            break; // nothing has changed
-                        }
-
-                        bit = -1; // This line makes the different events merge into the same tick
-                        continue;
-                    }
-                    else if (bit >= 2 && bit <= 9)
-                    {
-                        hasSteer = true;
-                        
-                        if (bitSet)
-                        {
-                            steer |= (sbyte)(1 << (bit - 2));
-                        }
-                    }
-                    else if (bit == 10)
-                    {
-                        gas = bitSet;
-                    }
-                    else if (bit == 11)
-                    {
-                        brake = bitSet;
-                    }
-                    else if (bit == 12 && !bitSet)
-                    {
-                        bit = -1; // This line makes the different events merge into the same tick
-                        position--;
+                        different = true;
                     }
                 }
 
-                if (somethingHasChanged)
+                if (different)
                 {
-                    yield return new(TimeInt32.FromMilliseconds(i * 10), hasSteer ? steer : null, gas, brake, horn, isRespawn);
+                    yield return new ShootmaniaInputChange(i, mouseAccuX, mouseAccuY, strafe, walk, vertical, states);
                 }
+            }
+
+            var theRest = r.ReadToEnd();
+
+            if (theRest.Any(x => x != 0))
+            {
+                throw new Exception("Input buffer not cleared out completely");
             }
         }
 
-        public record struct InputChange(TimeInt32 Timestamp, sbyte? Steer, bool? Gas, bool? Brake, bool? Horn, bool IsRespawn);
+        internal IEnumerable<IInputChange> ProcessTrackmaniaInputs()
+        {
+            var r = new BitReader(data);
+
+            for (var i = 0; i < ticks; i++)
+            {
+                var different = false;
+
+                var states = default(ulong?);
+                var mouseAccuX = default(short?);
+                var mouseAccuY = default(short?);
+                var steer = default(sbyte?);
+                var gas = default(bool?);
+                var brake = default(bool?);
+
+                var sameState = r.ReadBit();
+
+                if (!sameState)
+                {
+                    var onlySomething = r.ReadBit();
+
+                    states = onlySomething
+                        ? r.Read2Bit()
+                        : r.ReadNumber(bits: version is EVersion._2020_04_08 ? 33 : 34);
+
+                    different = true;
+                }
+
+                var sameMouse = r.ReadBit();
+
+                if (!sameMouse)
+                {
+                    mouseAccuX = r.ReadInt16();
+                    mouseAccuY = r.ReadInt16();
+
+                    different = true;
+                }
+
+                // This check is a bit weird, may not work for StormMan gameplay
+                // If starting with horn on, it is included on first tick
+                // If mouse is not plugged, it is also included
+                // In code, this check is presented as '(X - 2 & 0xfffffffd) == 0'
+
+                if (states.HasValue || i > 0)
+                {
+                    var sameValue = r.ReadBit();
+
+                    if (!sameValue)
+                    {
+                        steer = r.ReadSByte();
+                        gas = r.ReadBit();
+                        brake = r.ReadBit();
+
+                        different = true;
+                    }
+                }
+
+                if (different)
+                {
+                    yield return new TrackmaniaInputChange(i, states, mouseAccuX, mouseAccuY, steer, gas, brake);
+                }
+            }
+
+            var theRest = r.ReadToEnd();
+
+            if (theRest.Any(x => x != 0))
+            {
+                throw new Exception("Input buffer not cleared out completely");
+            }
+        }
+
+        public enum EStrafe : byte
+        {
+            None,
+            Left,
+            Corrupted,
+            Right
+        }
+
+        public enum EWalk : byte
+        {
+            None,
+            Forward,
+            Corrupted,
+            Backward
+        }
+
+        public interface IInputChange
+        {
+            int Tick { get; }
+            short? MouseAccuX { get; }
+            short? MouseAccuY { get; }
+            ulong? States { get; }
+
+            TimeInt32 Timestamp { get; }
+        }
+
+        public record struct ShootmaniaInputChange(int Tick,
+                                                   short? MouseAccuX,
+                                                   short? MouseAccuY,
+                                                   EStrafe? Strafe,
+                                                   EWalk? Walk,
+                                                   byte? Vertical,
+                                                   int? States) : IInputChange
+        {
+            public TimeInt32 Timestamp => new(Tick * 10);
+
+            public bool? IsGunTrigger => States is null ? null : (States & 2) != 0;
+            public bool? FreeLook => States is null ? null : (States & 4) != 0;
+            public bool? Fly => States is null ? null : (States & 8) != 0;
+            public bool? Camera2 => States is null ? null : (States & 32) != 0;
+            public bool? Jump => States is null ? null : (States & 128) != 0;
+            public bool? IsAction => States is null ? null : (States & 257) != 0;
+            public bool? ActionSlot1 => States is null ? null : (States & 1024) != 0;
+            public bool? ActionSlot2 => States is null ? null : (States & 2048) != 0;
+            public bool? ActionSlot3 => States is null ? null : (States & 4096) != 0;
+            public bool? ActionSlot4 => States is null ? null : (States & 8192) != 0;
+            public bool? Use1 => States is null ? null : (States & 16896) != 0;
+            public bool? Use2 => States is null ? null : (States & 32832) != 0;
+            public bool? Menu => States is null ? null : (States & 65536) != 0;
+            public bool? Horn => States is null ? null : (States & 1048576) != 0;
+            public bool? Respawn => States is null ? null : (States & 2097152) != 0;
+
+            ulong? IInputChange.States => States is null ? null : (ulong)States;
+        }
+
+        public record struct TrackmaniaInputChange(int Tick,
+                                                   ulong? States,
+                                                   short? MouseAccuX,
+                                                   short? MouseAccuY,
+                                                   sbyte? Steer,
+                                                   bool? Gas,
+                                                   bool? Brake) : IInputChange
+        {
+            public TimeInt32 Timestamp { get; } = new(Tick * 10);
+
+            public bool? Respawn => States is null ? null : (States & 2147483648) != 0;
+            public bool? Horn => null;
+        }
     }
 }

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.cs
@@ -1343,5 +1343,18 @@ public partial class CGameCtnGhost : CGameGhost
 
     #endregion
 
+    #region 0x02E skippable chunk
+
+    /// <summary>
+    /// CGameCtnGhost 0x02E skippable chunk
+    /// </summary>
+    [Chunk(0x0309202E), IgnoreChunk]
+    public class Chunk0309202E : SkippableChunk<CGameCtnGhost>
+    {
+
+    }
+
+    #endregion
+
     #endregion
 }

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.cs
@@ -913,7 +913,7 @@ public partial class CGameCtnGhost : CGameGhost
 
         public override void ReadWrite(CGameCtnGhost n, GameBoxReaderWriter rw)
         {
-            rw.Int32(ref U01);
+            rw.Int32(ref U01); // some validation version
         }
     }
 

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockTriangles.Key.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockTriangles.Key.cs
@@ -31,7 +31,7 @@ public abstract partial class CGameCtnMediaBlockTriangles
         public Key(CGameCtnMediaBlockTriangles node)
         {
             this.node = node;
-            positions = new Vec3[node.vertices?.Length ?? 0];
+            positions = new Vec3[node.vertices.Length];
         }
     }
 }

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockTriangles.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockTriangles.cs
@@ -185,6 +185,24 @@ public abstract partial class CGameCtnMediaBlockTriangles : CGameCtnMediaBlock, 
         }
     }
 
+    #region 0x002 chunk
+
+    /// <summary>
+    /// CGameCtnMediaBlockTriangles 0x002 skippable chunk
+    /// </summary>
+    [Chunk(0x03029002)]
+    public class Chunk03029002 : SkippableChunk<CGameCtnMediaBlockTriangles>
+    {
+        public int U01;
+
+        public override void ReadWrite(CGameCtnMediaBlockTriangles n, GameBoxReaderWriter rw)
+        {
+            rw.Int32(ref U01);
+        }
+    }
+
+    #endregion
+
     #endregion
 
     #endregion

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockTriangles.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockTriangles.cs
@@ -10,9 +10,9 @@ public abstract partial class CGameCtnMediaBlockTriangles : CGameCtnMediaBlock, 
 {
     #region Fields
 
-    private IList<Key> keys;
-    private Vec4[] vertices;
-    private Int3[] triangles;
+    private IList<Key> keys = Array.Empty<Key>();
+    private Vec4[] vertices = Array.Empty<Vec4>();
+    private Int3[] triangles = Array.Empty<Int3>();
 
     #endregion
 
@@ -83,9 +83,7 @@ public abstract partial class CGameCtnMediaBlockTriangles : CGameCtnMediaBlock, 
 
     internal CGameCtnMediaBlockTriangles()
     {
-        keys = Array.Empty<Key>();
-        vertices = Array.Empty<Vec4>();
-        triangles = Array.Empty<Int3>();
+        
     }
 
     #endregion

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockTriangles3D.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockTriangles3D.cs
@@ -1,4 +1,6 @@
-﻿namespace GBX.NET.Engines.Game;
+﻿using GBX.NET.Builders.Engines.Game;
+
+namespace GBX.NET.Engines.Game;
 
 /// <summary>
 /// MediaTracker block - 3D triangles.
@@ -12,4 +14,7 @@ public class CGameCtnMediaBlockTriangles3D : CGameCtnMediaBlockTriangles
     {
 
     }
+    
+    /// <param name="vertices">Array of vertex colors.</param>
+    public static CGameCtnMediaBlockTriangles3DBuilder Create(Vec4[] vertices) => new(vertices);
 }

--- a/Src/GBX.NET/Engines/Game/CGameCtnReplayRecord.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnReplayRecord.cs
@@ -754,8 +754,8 @@ public partial class CGameCtnReplayRecord : CMwNod, CGameCtnReplayRecord.IHeader
         {
             _ = r.ReadInt32(); // listVersion
             n.ghosts = r.ReadArray(r => r.ReadNodeRef<CGameCtnGhost>()!);
-            U01 = r.ReadInt32();
-            n.extras = r.ReadArray(r => r.ReadInt64());
+            U01 = r.ReadInt32(); // always zero
+            n.extras = r.ReadArray(r => r.ReadInt64()); // SOldShowTime
         }
 
         public override async Task ReadAsync(CGameCtnReplayRecord n, GameBoxReader r, CancellationToken cancellationToken = default)
@@ -900,7 +900,17 @@ public partial class CGameCtnReplayRecord : CMwNod, CGameCtnReplayRecord.IHeader
     [Chunk(0x0309301F, "AnchoredObjectInfos"), IgnoreChunk]
     public class Chunk0309301F : SkippableChunk<CGameCtnReplayRecord>
     {
-
+        /*
+         * version 1: SOldGameCtnReplayRecord_AnchoredObjectInfos array
+         * - bool
+         * - int
+         * - float
+         * - float
+         * - float
+         * - int
+         * 
+         * version 2: noderef CGameReplayObjectVisData m_Scenery_Objects_Deprecated
+         */
     }
 
     #endregion

--- a/Src/GBX.NET/Engines/Game/CGameGhost.cs
+++ b/Src/GBX.NET/Engines/Game/CGameGhost.cs
@@ -16,7 +16,7 @@ public partial class CGameGhost : CMwNod
     [AppliedWithChunk<Chunk0303F006>]
     public bool IsReplaying { get => isReplaying; set => isReplaying = value; }
 
-    [NodeMember]
+    [NodeMember(ExactName = "TM_Data")]
     [AppliedWithChunk<Chunk0303F003>]
     [AppliedWithChunk<Chunk0303F005>]
     [AppliedWithChunk<Chunk0303F006>]
@@ -92,7 +92,7 @@ public partial class CGameGhost : CMwNod
 
                 ghostData.ReadSamples(ms, numSamples: Samples?.Length ?? 0, sizePerSample: 56);
 
-                if (ghostData.NodeID == uint.MaxValue)
+                if (ghostData.SavedMobilClassId == uint.MaxValue)
                     return null;
 
                 return ghostData;
@@ -149,7 +149,7 @@ public partial class CGameGhost : CMwNod
                     using var ms = new MemoryStream(Data);
                     ghostData.Read(ms, compressed: true);
 
-                    if (ghostData.NodeID == uint.MaxValue)
+                    if (ghostData.SavedMobilClassId == uint.MaxValue)
                         return null;
 
                     return ghostData;

--- a/Src/GBX.NET/Engines/GameData/CGameCtnCollector.IHeader.cs
+++ b/Src/GBX.NET/Engines/GameData/CGameCtnCollector.IHeader.cs
@@ -14,6 +14,6 @@ public partial class CGameCtnCollector
         public EProdState? ProdState { get; set; }
         public Color[,]? Icon { get; set; }
         public byte[]? IconWebP { get; set; }
-        public long FileTime { get; set; }
+        public ulong FileTime { get; set; }
     }
 }

--- a/Src/GBX.NET/Engines/GameData/CGameCtnCollector.IHeader.cs
+++ b/Src/GBX.NET/Engines/GameData/CGameCtnCollector.IHeader.cs
@@ -6,7 +6,7 @@ public partial class CGameCtnCollector
 {
     public interface IHeader : INodeHeader<CGameCtnCollector>
     {
-        public Ident Author { get; set; }
+        public Ident Ident { get; set; }
         public string PageName { get; set; }
         public ECollectorFlags Flags { get; set; }
         public int CatalogPosition { get; set; }

--- a/Src/GBX.NET/Engines/GameData/CGameCtnCollector.cs
+++ b/Src/GBX.NET/Engines/GameData/CGameCtnCollector.cs
@@ -44,7 +44,7 @@ public partial class CGameCtnCollector : CMwNod, CGameCtnCollector.IHeader
     private string? skinDirectory;
     private bool isInternal;
     private bool isAdvanced;
-    private long fileTime;
+    private ulong fileTime;
 
     #endregion
 
@@ -100,7 +100,7 @@ public partial class CGameCtnCollector : CMwNod, CGameCtnCollector.IHeader
 
     [NodeMember]
     [AppliedWithChunk<Chunk2E001006H>]
-    public long FileTime { get => fileTime; set => fileTime = value; }
+    public ulong FileTime { get => fileTime; set => fileTime = value; }
 
     [NodeMember(ExactlyNamed = true)]
     [AppliedWithChunk<Chunk2E001009>]
@@ -173,8 +173,8 @@ public partial class CGameCtnCollector : CMwNod, CGameCtnCollector.IHeader
 
         public int Version { get => version; set => version = value; }
 
-        public int U01;
-        public int U02;
+        public string U01 = "";
+        public string? U02;
         public int U03;
         public byte U04;
         public int U05;
@@ -183,17 +183,17 @@ public partial class CGameCtnCollector : CMwNod, CGameCtnCollector.IHeader
         public override void ReadWrite(CGameCtnCollector n, GameBoxReaderWriter rw)
         {
             rw.Ident(ref n.author!);
-            rw.Int32(ref version);
+            rw.Int32(ref version); // Id but filtered, technically
             rw.String(ref n.pageName!);
 
             if (version == 5)
             {
-                rw.Int32(ref U01);
+                rw.Id(ref U01!);
             }
 
             if (version >= 4)
             {
-                rw.Int32(ref U02); // Id?
+                rw.Id(ref U02);
             }
 
             if (version >= 3)
@@ -314,7 +314,7 @@ public partial class CGameCtnCollector : CMwNod, CGameCtnCollector.IHeader
     {
         public override void ReadWrite(CGameCtnCollector n, GameBoxReaderWriter rw)
         {
-            rw.Int64(ref n.fileTime);
+            rw.UInt64(ref n.fileTime); // SHeaderLightMap
         }
     }
 
@@ -439,7 +439,7 @@ public partial class CGameCtnCollector : CMwNod, CGameCtnCollector.IHeader
     {
         public override void ReadWrite(CGameCtnCollector n, GameBoxReaderWriter rw)
         {
-            rw.Ident(ref n.author!);
+            rw.Ident(ref n.author!); // It may be called Ident
         }
     }
 
@@ -505,7 +505,7 @@ public partial class CGameCtnCollector : CMwNod, CGameCtnCollector.IHeader
         private int version;
 
         public CMwNod? U01;
-        public int U02;
+        public CMwNod? U02;
 
         public int Version { get => version; set => version = value; }
 
@@ -515,9 +515,9 @@ public partial class CGameCtnCollector : CMwNod, CGameCtnCollector.IHeader
             rw.NodeRef(ref U01);
             rw.String(ref n.skinDirectory);
 
-            if (version >= 2 && n.skinDirectory!.Length == 0)
+            if (version >= 2 && (n.skinDirectory is null || n.skinDirectory.Length == 0))
             {
-                rw.Int32(ref U02); // -1
+                rw.NodeRef(ref U02);
             }
         }
     }

--- a/Src/GBX.NET/Engines/GameData/CGameCtnCollector.cs
+++ b/Src/GBX.NET/Engines/GameData/CGameCtnCollector.cs
@@ -32,7 +32,7 @@ public partial class CGameCtnCollector : CMwNod, CGameCtnCollector.IHeader
 
     #region Fields
 
-    private Ident author;
+    private Ident ident;
     private string pageName;
     private ECollectorFlags flags;
     private int catalogPosition;
@@ -56,7 +56,7 @@ public partial class CGameCtnCollector : CMwNod, CGameCtnCollector.IHeader
     [AppliedWithChunk<Chunk2E001002>]
     [AppliedWithChunk<Chunk2E001003>]
     [AppliedWithChunk<Chunk2E00100B>]
-    public Ident Author { get => author; set => author = value; }
+    public Ident Ident { get => ident; set => ident = value; }
 
     [NodeMember(ExactlyNamed = true)]
     [AppliedWithChunk<Chunk2E001003>]
@@ -137,7 +137,7 @@ public partial class CGameCtnCollector : CMwNod, CGameCtnCollector.IHeader
 
     internal CGameCtnCollector()
     {
-        author = Ident.Empty;
+        ident = Ident.Empty;
         pageName = "";
     }
 
@@ -155,7 +155,7 @@ public partial class CGameCtnCollector : CMwNod, CGameCtnCollector.IHeader
     {
         public override void ReadWrite(CGameCtnCollector n, GameBoxReaderWriter rw)
         {
-            rw.Ident(ref n.author!);
+            rw.Ident(ref n.ident!);
         }
     }
 
@@ -182,7 +182,7 @@ public partial class CGameCtnCollector : CMwNod, CGameCtnCollector.IHeader
 
         public override void ReadWrite(CGameCtnCollector n, GameBoxReaderWriter rw)
         {
-            rw.Ident(ref n.author!);
+            rw.Ident(ref n.ident!);
             rw.Int32(ref version); // Id but filtered, technically
             rw.String(ref n.pageName!);
 
@@ -439,7 +439,7 @@ public partial class CGameCtnCollector : CMwNod, CGameCtnCollector.IHeader
     {
         public override void ReadWrite(CGameCtnCollector n, GameBoxReaderWriter rw)
         {
-            rw.Ident(ref n.author!); // It may be called Ident
+            rw.Ident(ref n.ident!); // It may be called Ident
         }
     }
 

--- a/Src/GBX.NET/Engines/Plug/CPlugMaterial.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugMaterial.cs
@@ -200,18 +200,21 @@ public class CPlugMaterial : CPlug
             get => shader1 = node?.GetNodeFromRefTable(shader1, shader1File) as CPlugShader;
             set => shader1 = value;
         }
+        public GameBoxRefTable.File? Shader1File { get => shader1File; set => shader1File = value; }
 
         public CPlugShader? Shader2
         {
             get => shader2 = node?.GetNodeFromRefTable(shader2, shader2File) as CPlugShader;
             set => shader2 = value;
         }
+        public GameBoxRefTable.File? Shader2File { get => shader2File; set => shader2File = value; }
 
         public CPlugShader? Shader3
         {
             get => shader3 = node?.GetNodeFromRefTable(shader3, shader3File) as CPlugShader;
             set => shader3 = value;
         }
+        public GameBoxRefTable.File? Shader3File { get => shader3File; set => shader3File = value; }
 
         public void ReadWrite(GameBoxReaderWriter rw, GameBox? gbx, int version = 0)
         {

--- a/Src/GBX.NET/Engines/Plug/CPlugSolid.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugSolid.cs
@@ -11,10 +11,16 @@ namespace GBX.NET.Engines.Plug;
 [NodeExtension("Solid")]
 public class CPlugSolid : CPlug
 {
+    private int typeAndIndex;
     private CPlug? tree;
     private GameBoxRefTable.File? treeFile;
+    private PreLightGen? solidPreLightGen;
+    private ulong fileWriteTime;
 
-    [NodeMember]
+    [NodeMember(ExactlyNamed = true)]
+    public int TypeAndIndex { get => typeAndIndex; set => typeAndIndex = value; }
+    
+    [NodeMember(ExactlyNamed = true)]
     [AppliedWithChunk<Chunk0900500D>]
     [AppliedWithChunk<Chunk09005011>]
     public CPlug? Tree
@@ -22,6 +28,14 @@ public class CPlugSolid : CPlug
         get => tree = GetNodeFromRefTable(tree, treeFile) as CPlug;
         set => tree = value;
     }
+
+    [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk<Chunk09005017>]
+    public PreLightGen? SolidPreLightGen { get => solidPreLightGen; set => solidPreLightGen = value; }
+
+    [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk<Chunk09005017>]
+    public ulong FileWriteTime { get => fileWriteTime; set => fileWriteTime = value; }
 
     internal CPlugSolid()
     {
@@ -86,11 +100,9 @@ public class CPlugSolid : CPlug
     [Chunk(0x09005000)]
     public class Chunk09005000 : Chunk<CPlugSolid>
     {
-        public int U01;
-
         public override void ReadWrite(CPlugSolid n, GameBoxReaderWriter rw)
         {
-            rw.Int32(ref U01);
+            rw.Int32(ref n.typeAndIndex);
         }
     }
 
@@ -107,15 +119,7 @@ public class CPlugSolid : CPlug
         public float U05;
         public float U06;
 
-        public float U07;
-        public float U08;
-        public float U09;
-        public float U10;
-        public float U11;
-        public float U12;
-        public float U13;
-        public float U14;
-        public float U15;
+        public Mat3 U07;
 
         public override void ReadWrite(CPlugSolid n, GameBoxReaderWriter rw)
         {
@@ -126,15 +130,7 @@ public class CPlugSolid : CPlug
             rw.Single(ref U05);
             rw.Single(ref U06);
 
-            rw.Single(ref U07);
-            rw.Single(ref U08);
-            rw.Single(ref U09);
-            rw.Single(ref U10);
-            rw.Single(ref U11);
-            rw.Single(ref U12);
-            rw.Single(ref U13);
-            rw.Single(ref U14);
-            rw.Single(ref U15);
+            rw.Mat3(ref U07);
         }
     }
 
@@ -184,45 +180,30 @@ public class CPlugSolid : CPlug
     [Chunk(0x0900500C)]
     public class Chunk0900500C : Chunk<CPlugSolid>
     {
-        public bool U01;
-        public bool U02;
-        public bool U03;
-        public bool U04;
-        public bool U05;
-        public bool U06;
-        public bool U07;
-        public bool U08;
-        public bool U09;
-        public bool U10;
-        public float U11;
-        public int U12;
-        public float U13;
-        public float U14;
-        public float U15;
-        public float U16;
-        public int U17;
-        public int U18;
+        public bool U01; // always false
+        public float U02; // always zero
+        public int U03; // always zero
 
         public override void ReadWrite(CPlugSolid n, GameBoxReaderWriter rw)
         {
             rw.Boolean(ref U01);
-            rw.Boolean(ref U02);
-            rw.Boolean(ref U03);
-            rw.Boolean(ref U04);
-            rw.Boolean(ref U05);
-            rw.Boolean(ref U06);
-            rw.Boolean(ref U07);
-            rw.Boolean(ref U08);
-            rw.Boolean(ref U09);
-            rw.Boolean(ref U10);
-            rw.Single(ref U11);
-            rw.Int32(ref U12);
-            rw.Single(ref U13);
-            rw.Single(ref U14);
-            rw.Single(ref U15);
-            rw.Single(ref U16);
-            rw.Int32(ref U17);
-            rw.Int32(ref U18);
+            rw.Boolean(ref U01);
+            rw.Boolean(ref U01);
+            rw.Boolean(ref U01);
+            rw.Boolean(ref U01);
+            rw.Boolean(ref U01);
+            rw.Boolean(ref U01);
+            rw.Boolean(ref U01);
+            rw.Boolean(ref U01);
+            rw.Boolean(ref U01);
+            rw.Single(ref U02);
+            rw.Int32(ref U03);
+            rw.Single(ref U02);
+            rw.Single(ref U02);
+            rw.Single(ref U02);
+            rw.Single(ref U02);
+            rw.Int32(ref U03);
+            rw.Int32(ref U03);
         }
     }
 
@@ -264,7 +245,7 @@ public class CPlugSolid : CPlug
 
         public override void ReadWrite(CPlugSolid n, GameBoxReaderWriter rw)
         {
-            rw.Single(ref U01);
+            rw.Single(ref U01); // probably related to CPlugPhysicalObject::SetComPos
             rw.Single(ref U02);
             rw.Single(ref U03);
             rw.Single(ref U04);
@@ -299,7 +280,7 @@ public class CPlugSolid : CPlug
 
         public override void ReadWrite(CPlugSolid n, GameBoxReaderWriter rw)
         {
-            rw.NodeRef(ref U01);
+            rw.NodeRef(ref U01); // CSceneVehicleEnvironment
         }
     }
 
@@ -323,7 +304,7 @@ public class CPlugSolid : CPlug
                 rw.Boolean(ref U03);
             }
 
-            rw.NodeRef<CPlug>(ref n.tree, ref n.treeFile);
+            rw.NodeRef<CPlug>(ref n.tree, ref n.treeFile); // only of U02 is false?
         }
 
         public override async Task ReadWriteAsync(CPlugSolid n, GameBoxReaderWriter rw, CancellationToken cancellationToken = default)
@@ -336,7 +317,7 @@ public class CPlugSolid : CPlug
                 rw.Boolean(ref U03);
             }
             
-            n.tree = await rw.NodeRefAsync<CPlug>(n.tree, cancellationToken);
+            n.tree = await rw.NodeRefAsync<CPlug>(n.tree, cancellationToken); // only of U02 is false?
         }
     }
 
@@ -350,16 +331,16 @@ public class CPlugSolid : CPlug
 
         public override void ReadWrite(CPlugSolid n, GameBoxReaderWriter rw)
         {
-            rw.Byte(ref U01);
+            rw.Byte(ref U01); // relates ti SolidPreLightGen
         }
     }
 
-    #region 0x017 chunk
+    #region 0x017 chunk (SolidPreLightGen)
 
     /// <summary>
-    /// CPlugSolid 0x017 chunk
+    /// CPlugSolid 0x017 chunk (SolidPreLightGen)
     /// </summary>
-    [Chunk(0x09005017)]
+    [Chunk(0x09005017, "SolidPreLightGen")]
     public class Chunk09005017 : Chunk<CPlugSolid>, IVersionable
     {
         private int version = 3;
@@ -371,7 +352,6 @@ public class CPlugSolid : CPlug
         public Rect U05;
         public Int2 U06;
         public Box U07;
-        public ulong U08;
         public bool U09;
         public PreLightGen? U10;
 
@@ -387,7 +367,7 @@ public class CPlugSolid : CPlug
 
                 if (U09)
                 {
-                    rw.Archive<PreLightGen>(ref U10);
+                    rw.Archive<PreLightGen>(ref n.solidPreLightGen);
                 }
             }
             else
@@ -407,7 +387,7 @@ public class CPlugSolid : CPlug
 
             if (version >= 2)
             {
-                rw.UInt64(ref U08);
+                rw.UInt64(ref n.fileWriteTime);
             }
         }
     }
@@ -426,14 +406,14 @@ public class CPlugSolid : CPlug
         private int listVersion1 = 10;
         private int listVersion2 = 10;
 
-        private CPlugSound?[]? U01;
-        private CPlugParticleEmitterModel?[]? U02;
-        private LocatedInstance[]? U03;
-        private LocatedInstance[]? U04;
-        private int U05;
-        private string[]? U06;
-        private Iso4[]? U07;
-        private string? U08;
+        public CPlugSound?[]? U01;
+        public CPlugParticleEmitterModel?[]? U02;
+        public LocatedInstance[]? U03;
+        public LocatedInstance[]? U04;
+        public int U05;
+        public string[]? U06;
+        public Iso4[]? U07;
+        public string? U08;
 
         public int Version { get => version; set => version = value; }
 

--- a/Src/GBX.NET/Engines/Plug/CPlugSolid.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugSolid.cs
@@ -15,7 +15,7 @@ public class CPlugSolid : CPlug
     private CPlug? tree;
     private GameBoxRefTable.File? treeFile;
     private PreLightGen? solidPreLightGen;
-    private ulong fileWriteTime;
+    private DateTime? fileWriteTime;
 
     [NodeMember(ExactlyNamed = true)]
     public int TypeAndIndex { get => typeAndIndex; set => typeAndIndex = value; }
@@ -35,7 +35,7 @@ public class CPlugSolid : CPlug
 
     [NodeMember(ExactlyNamed = true)]
     [AppliedWithChunk<Chunk09005017>]
-    public ulong FileWriteTime { get => fileWriteTime; set => fileWriteTime = value; }
+    public DateTime? FileWriteTime { get => fileWriteTime; set => fileWriteTime = value; }
 
     internal CPlugSolid()
     {
@@ -387,7 +387,7 @@ public class CPlugSolid : CPlug
 
             if (version >= 2)
             {
-                rw.UInt64(ref n.fileWriteTime);
+                rw.FileTime(ref n.fileWriteTime);
             }
         }
     }

--- a/Src/GBX.NET/Engines/Plug/CPlugSurface.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugSurface.cs
@@ -124,7 +124,7 @@ public class CPlugSurface : CPlug
 
             rw.NodeRef(ref n.geom);
 
-            rw.ArrayArchive<SurfMaterial>(n.materials);
+            rw.ArrayArchiveWithGbx<SurfMaterial>(ref n.materials);
         }
     }
 
@@ -202,7 +202,7 @@ public class CPlugSurface : CPlug
 
         public void ReadWrite(GameBoxReaderWriter rw, int version = 0)
         {
-            if (rw.Boolean(material is not null))
+            if (rw.Boolean(material is not null || materialFile is not null))
             {
                 rw.NodeRef(ref material, ref materialFile);
             }

--- a/Src/GBX.NET/Engines/Plug/CPlugSurface.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugSurface.cs
@@ -222,18 +222,15 @@ public class CPlugSurface : CPlug
     public class Box : ISurf
     {
         private NET.Box transform;
-        private short u02;
 
         public int Id => 6;
         public Vec3? U01 { get; set; }
 
         public NET.Box Transform { get => transform; set => transform = value; }
-        public short U02 { get => u02; set => u02 = value; }
 
         public void ReadWrite(GameBoxReaderWriter rw, int version = 0)
         {
             rw.Box(ref transform);
-            rw.Int16(ref u02);
         }
     }
 

--- a/Src/GBX.NET/Engines/Plug/CPlugVisual3D.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugVisual3D.cs
@@ -96,8 +96,10 @@ public abstract class CPlugVisual3D : CPlugVisual
         {
             var u01 = !n.IsFlagBitSet(22) || n.HasVertexNormals;
             var u02 = !n.IsFlagBitSet(22) || n.IsFlagBitSet(8);
+            var u03 = n.IsFlagBitSet(20);
+            var u04 = n.IsFlagBitSet(21);
+            var isSprite = n is CPlugVisualSprite;
 
-            // Console.WriteLine("numBytesPerVertex={0}", numBytesPerVertex);
             n.vertices = r.ReadArray(n.Count, r =>
             {
                 var pos = r.ReadVec3();
@@ -108,7 +110,7 @@ public abstract class CPlugVisual3D : CPlugVisual
 
                 if (u01)
                 {
-                    if (n.IsFlagBitSet(20))
+                    if (u03)
                     {
                         vertU01 = r.ReadInt32();
                     }
@@ -120,7 +122,7 @@ public abstract class CPlugVisual3D : CPlugVisual
 
                 if (u02)
                 {
-                    if (n.IsFlagBitSet(21))
+                    if (u04)
                     {
                         vertU03 = r.ReadInt32();
                     }
@@ -129,6 +131,15 @@ public abstract class CPlugVisual3D : CPlugVisual
                         vertU04 = r.ReadVec4();
                     }
                 }
+                
+                var vertU05 = default(float?);
+                var vertU06 = default(int?);
+
+                if (isSprite)
+                {
+                    vertU05 = r.ReadSingle();
+                    vertU06 = r.ReadInt32();
+                }
 
                 return new Vertex
                 {
@@ -136,7 +147,9 @@ public abstract class CPlugVisual3D : CPlugVisual
                     U04 = vertU01,
                     U05 = vertU02,
                     U06 = vertU03,
-                    U07 = vertU04
+                    U07 = vertU04,
+                    U08 = vertU05,
+                    U09 = vertU06,
                 };
             });
 
@@ -148,7 +161,10 @@ public abstract class CPlugVisual3D : CPlugVisual
         {
             var u01 = !n.IsFlagBitSet(22) || n.HasVertexNormals;
             var u02 = !n.IsFlagBitSet(22) || n.IsFlagBitSet(8);
-            
+            var u03 = n.IsFlagBitSet(20);
+            var u04 = n.IsFlagBitSet(21);
+            var isSprite = n is CPlugVisualSprite;
+
             for (var i = 0; i < n.Count; i++)
             {
                 var v = n.vertices[i];
@@ -156,7 +172,7 @@ public abstract class CPlugVisual3D : CPlugVisual
 
                 if (u01)
                 {
-                    if (n.IsFlagBitSet(20))
+                    if (u03)
                     {
                         w.Write(v.U04.GetValueOrDefault());
                     }
@@ -168,7 +184,7 @@ public abstract class CPlugVisual3D : CPlugVisual
 
                 if (u02)
                 {
-                    if (n.IsFlagBitSet(21))
+                    if (u04)
                     {
                         w.Write(v.U06.GetValueOrDefault());
                     }
@@ -176,6 +192,12 @@ public abstract class CPlugVisual3D : CPlugVisual
                     {
                         w.Write(v.U07.GetValueOrDefault());
                     }
+                }
+
+                if (isSprite)
+                {
+                    w.Write(v.U08.GetValueOrDefault());
+                    w.Write(v.U09.GetValueOrDefault());
                 }
             }
 
@@ -204,7 +226,7 @@ public abstract class CPlugVisual3D : CPlugVisual
         }
     }
 
-    public readonly record struct Vertex(Vec3 Position, Vec3? Normal, Vec3? U02, float? U03, int? U04, Vec3? U05, int? U06, Vec4? U07)
+    public readonly record struct Vertex(Vec3 Position, Vec3? Normal, Vec3? U02, float? U03, int? U04, Vec3? U05, int? U06, Vec4? U07, float? U08, int? U09)
     {
         public override string ToString() => Position.ToString();
     }

--- a/Src/GBX.NET/Engines/Scene/CSceneObject.cs
+++ b/Src/GBX.NET/Engines/Scene/CSceneObject.cs
@@ -4,6 +4,12 @@
 [Node(0x0A005000)]
 public abstract class CSceneObject : CMwNod
 {
+    private CMotion? motion;
+
+    [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk<Chunk0A005003>]
+    public CMotion? Motion { get => motion; set => motion = value; }
+
     internal CSceneObject()
     {
 
@@ -33,7 +39,7 @@ public abstract class CSceneObject : CMwNod
 
         public override void ReadWrite(CSceneObject n, GameBoxReaderWriter rw)
         {
-            rw.Boolean(ref U01);
+            rw.Boolean(ref U01); // same as 0x004 U01
         }
     }
 
@@ -43,11 +49,9 @@ public abstract class CSceneObject : CMwNod
     [Chunk(0x0A005003)]
     public class Chunk0A005003 : Chunk<CSceneObject>
     {
-        public CMwNod? U01;
-
         public override void ReadWrite(CSceneObject n, GameBoxReaderWriter rw)
         {
-            rw.NodeRef(ref U01); // CMotion?
+            rw.NodeRef(ref n.motion);
         }
     }
 
@@ -61,7 +65,7 @@ public abstract class CSceneObject : CMwNod
 
         public override void ReadWrite(CSceneObject n, GameBoxReaderWriter rw)
         {
-            rw.Int32(ref U01);
+            rw.Int32(ref U01); // same as 0x002 U01
         }
     }
 }

--- a/Src/GBX.NET/GBX.NET.csproj
+++ b/Src/GBX.NET/GBX.NET.csproj
@@ -11,7 +11,7 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 
-		<Version>1.1.0</Version>
+		<Version>1.1.1</Version>
 		<PackageReleaseNotes></PackageReleaseNotes>
 
 		<TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>

--- a/Src/GBX.NET/GameBoxReader.cs
+++ b/Src/GBX.NET/GameBoxReader.cs
@@ -2093,4 +2093,9 @@ public class GameBoxReader : BinaryReader
     {
         return ReadExternalNodeArray<T>(length: ReadInt32());
     }
+
+    public DateTime ReadFileTime()
+    {
+        return DateTime.FromFileTimeUtc(ReadInt64());
+    }
 }

--- a/Src/GBX.NET/GameBoxReader.cs
+++ b/Src/GBX.NET/GameBoxReader.cs
@@ -422,6 +422,19 @@ public class GameBoxReader : BinaryReader
                         TZ: ReadSingle());
     }
 
+    public Mat3 ReadMat3()
+    {
+        return new Mat3(XX: ReadSingle(),
+                        XY: ReadSingle(),
+                        XZ: ReadSingle(),
+                        YX: ReadSingle(),
+                        YY: ReadSingle(),
+                        YZ: ReadSingle(),
+                        ZX: ReadSingle(),
+                        ZY: ReadSingle(),
+                        ZZ: ReadSingle());
+    }
+
     public Mat4 ReadMat4()
     {
         return new Mat4(XX: ReadSingle(),

--- a/Src/GBX.NET/GameBoxReaderWriter.cs
+++ b/Src/GBX.NET/GameBoxReaderWriter.cs
@@ -2175,7 +2175,7 @@ public partial class GameBoxReaderWriter
     public Node? NodeRef(Node? variable, ref GameBoxRefTable.File? nodeRefFile)
     {
         if (Reader is not null) variable = Reader.ReadNodeRef(out nodeRefFile);
-        if (Writer is not null) Writer.Write(variable);
+        if (Writer is not null) Writer.Write(variable, nodeRefFile);
         return variable;
     }
 

--- a/Src/GBX.NET/GameBoxReaderWriter.cs
+++ b/Src/GBX.NET/GameBoxReaderWriter.cs
@@ -1186,6 +1186,56 @@ public partial class GameBoxReaderWriter
     public void Iso4(ref Iso4? variable, Iso4 defaultValue = default) => variable = Iso4(variable, defaultValue);
 
     /// <summary>
+    /// Reads or writes an <see cref="NET.Mat3"/>.
+    /// </summary>
+    /// <param name="variable">Variable to write. Ignored in read mode.</param>
+    /// <returns>Value read in read mode. In write mode, <paramref name="variable"/> is returned.</returns>
+    /// <exception cref="EndOfStreamException">The end of the stream is reached.</exception>
+    /// <exception cref="ObjectDisposedException">The stream is closed.</exception>
+    /// <exception cref="IOException">An I/O error occurs.</exception>
+    public Mat3 Mat3(Mat3 variable = default)
+    {
+        if (Reader is not null) variable = Reader.ReadMat3();
+        if (Writer is not null) Writer.Write(variable);
+        return variable;
+    }
+
+    /// <summary>
+    /// Reads or writes a nullable <see cref="NET.Mat3"/>.
+    /// </summary>
+    /// <param name="variable">Variable to write. If null, <paramref name="defaultValue"/> is written. Ignored in read mode.</param>
+    /// <param name="defaultValue">Value written when <paramref name="variable"/> is null. Ignored in read mode.</param>
+    /// <returns>Value read in read mode. In write mode, <paramref name="variable"/> is returned (including null).</returns>
+    /// <exception cref="EndOfStreamException">The end of the stream is reached.</exception>
+    /// <exception cref="ObjectDisposedException">The stream is closed.</exception>
+    /// <exception cref="IOException">An I/O error occurs.</exception>
+    public Mat3? Mat3(Mat3? variable, Mat3 defaultValue = default)
+    {
+        if (Reader is not null) variable = Reader.ReadMat3();
+        if (Writer is not null) Writer.Write(variable.GetValueOrDefault(defaultValue));
+        return variable;
+    }
+
+    /// <summary>
+    /// Reads or writes an <see cref="NET.Mat3"/> through reference.
+    /// </summary>
+    /// <param name="variable">Variable to read or write. Read mode sets <paramref name="variable"/>, write mode uses <paramref name="variable"/> to write the value (keeping <paramref name="variable"/> unchanged).</param>
+    /// <exception cref="EndOfStreamException">The end of the stream is reached.</exception>
+    /// <exception cref="ObjectDisposedException">The stream is closed.</exception>
+    /// <exception cref="IOException">An I/O error occurs.</exception>
+    public void Mat3(ref Mat3 variable) => variable = Mat3(variable);
+
+    /// <summary>
+    /// Reads or writes a nullable <see cref="NET.Mat3"/> through reference.
+    /// </summary>
+    /// <param name="variable">Variable to read or write. Read mode sets <paramref name="variable"/>, write mode uses <paramref name="variable"/> to write the value (keeping <paramref name="variable"/> unchanged). If <paramref name="variable"/> is null, <paramref name="defaultValue"/> is written instead.</param>
+    /// <param name="defaultValue">Value written when <paramref name="variable"/> is null. Ignored in read mode.</param>
+    /// <exception cref="EndOfStreamException">The end of the stream is reached.</exception>
+    /// <exception cref="ObjectDisposedException">The stream is closed.</exception>
+    /// <exception cref="IOException">An I/O error occurs.</exception>
+    public void Mat3(ref Mat3? variable, Mat3 defaultValue = default) => variable = Mat3(variable, defaultValue);
+
+    /// <summary>
     /// Reads or writes an <see cref="NET.Mat4"/>.
     /// </summary>
     /// <param name="variable">Variable to write. Ignored in read mode.</param>

--- a/Src/GBX.NET/GameBoxReaderWriter.cs
+++ b/Src/GBX.NET/GameBoxReaderWriter.cs
@@ -1313,6 +1313,56 @@ public partial class GameBoxReaderWriter
     }
 
     /// <summary>
+    /// Reads or writes an <see cref="DateTime"/>.
+    /// </summary>
+    /// <param name="variable">Variable to write. Ignored in read mode.</param>
+    /// <returns>Value read in read mode. In write mode, <paramref name="variable"/> is returned.</returns>
+    /// <exception cref="EndOfStreamException">The end of the stream is reached.</exception>
+    /// <exception cref="ObjectDisposedException">The stream is closed.</exception>
+    /// <exception cref="IOException">An I/O error occurs.</exception>
+    public DateTime FileTime(DateTime variable = default)
+    {
+        if (Reader is not null) variable = Reader.ReadFileTime();
+        if (Writer is not null) Writer.Write(variable);
+        return variable;
+    }
+
+    /// <summary>
+    /// Reads or writes a nullable <see cref="DateTime"/>.
+    /// </summary>
+    /// <param name="variable">Variable to write. If null, <paramref name="defaultValue"/> is written. Ignored in read mode.</param>
+    /// <param name="defaultValue">Value written when <paramref name="variable"/> is null. Ignored in read mode.</param>
+    /// <returns>Value read in read mode. In write mode, <paramref name="variable"/> is returned (including null).</returns>
+    /// <exception cref="EndOfStreamException">The end of the stream is reached.</exception>
+    /// <exception cref="ObjectDisposedException">The stream is closed.</exception>
+    /// <exception cref="IOException">An I/O error occurs.</exception>
+    public DateTime? FileTime(DateTime? variable, DateTime defaultValue = default)
+    {
+        if (Reader is not null) variable = Reader.ReadFileTime();
+        if (Writer is not null) Writer.Write(variable.GetValueOrDefault(defaultValue));
+        return variable;
+    }
+
+    /// <summary>
+    /// Reads or writes an <see cref="DateTime"/> through reference.
+    /// </summary>
+    /// <param name="variable">Variable to read or write. Read mode sets <paramref name="variable"/>, write mode uses <paramref name="variable"/> to write the value (keeping <paramref name="variable"/> unchanged).</param>
+    /// <exception cref="EndOfStreamException">The end of the stream is reached.</exception>
+    /// <exception cref="ObjectDisposedException">The stream is closed.</exception>
+    /// <exception cref="IOException">An I/O error occurs.</exception>
+    public void FileTime(ref DateTime variable) => variable = FileTime(variable);
+
+    /// <summary>
+    /// Reads or writes a nullable <see cref="DateTime"/> through reference.
+    /// </summary>
+    /// <param name="variable">Variable to read or write. Read mode sets <paramref name="variable"/>, write mode uses <paramref name="variable"/> to write the value (keeping <paramref name="variable"/> unchanged). If <paramref name="variable"/> is null, <paramref name="defaultValue"/> is written instead.</param>
+    /// <param name="defaultValue">Value written when <paramref name="variable"/> is null. Ignored in read mode.</param>
+    /// <exception cref="EndOfStreamException">The end of the stream is reached.</exception>
+    /// <exception cref="ObjectDisposedException">The stream is closed.</exception>
+    /// <exception cref="IOException">An I/O error occurs.</exception>
+    public void FileTime(ref DateTime? variable, DateTime defaultValue = default) => variable = FileTime(variable, defaultValue);
+
+    /// <summary>
     /// Reads or writes a <see cref="NET.FileRef"/>.
     /// </summary>
     /// <param name="variable">Variable to write. Ignored in read mode.</param>

--- a/Src/GBX.NET/GameBoxWriter.cs
+++ b/Src/GBX.NET/GameBoxWriter.cs
@@ -371,28 +371,20 @@ public class GameBoxWriter : BinaryWriter
     {
         if (nodeFile is not null)
         {
-            var nodeFileIndex = nodeFile.NodeIndex;
-            var alreadyAdded = false;
-
-            while (AuxNodes.TryGetValue(nodeFileIndex, out Node? alreadyAddedNode))
+            foreach (var pair in State.ExtAuxNodes)
             {
-                if (alreadyAddedNode is null || node == alreadyAddedNode)
+                if (pair.Value == nodeFile)
                 {
-                    alreadyAdded = true;
-                    break;
+                    Write(pair.Key + 1);
+                    return;
                 }
-
-                nodeFileIndex++;
             }
 
-            nodeFile.NodeIndex = nodeFileIndex;
+            var i = AuxNodes.Count + State.ExtAuxNodes.Count;
+            nodeFile.NodeIndex = i;
+            State.ExtAuxNodes[i] = nodeFile;
 
-            Write(nodeFileIndex + 1);
-
-            if (!alreadyAdded)
-            {
-                AuxNodes.Add(nodeFileIndex, null);
-            }
+            Write(i + 1);
 
             return;
         }
@@ -424,12 +416,7 @@ public class GameBoxWriter : BinaryWriter
             }
         }
 
-        var index = AuxNodes.Count;
-
-        while (AuxNodes.ContainsKey(index))
-        {
-            index++;
-        }
+        var index = AuxNodes.Count + State.ExtAuxNodes.Count;
 
         AuxNodes.Add(index, node);
 

--- a/Src/GBX.NET/GameBoxWriter.cs
+++ b/Src/GBX.NET/GameBoxWriter.cs
@@ -200,6 +200,21 @@ public class GameBoxWriter : BinaryWriter
 
     /// <exception cref="IOException">An I/O error occurs.</exception>
     /// <exception cref="ObjectDisposedException">The stream is closed.</exception>
+    public void Write(Mat3 value)
+    {
+        Write(value.XX);
+        Write(value.XY);
+        Write(value.XZ);
+        Write(value.YX);
+        Write(value.YY);
+        Write(value.YZ);
+        Write(value.ZX);
+        Write(value.ZY);
+        Write(value.ZZ);
+    }
+
+    /// <exception cref="IOException">An I/O error occurs.</exception>
+    /// <exception cref="ObjectDisposedException">The stream is closed.</exception>
     public void Write(Mat4 value)
     {
         Write(value.XX);

--- a/Src/GBX.NET/GameBoxWriter.cs
+++ b/Src/GBX.NET/GameBoxWriter.cs
@@ -984,4 +984,9 @@ public class GameBoxWriter : BinaryWriter
     {
         WriteArray(array, (x, w) => w.Write(x.Node, x.File));
     }
+
+    public void Write(DateTime variable)
+    {
+        Write(variable.ToFileTimeUtc());
+    }
 }

--- a/Src/GBX.NET/GbxState.cs
+++ b/Src/GBX.NET/GbxState.cs
@@ -4,10 +4,12 @@ public class GbxState
 {
     private IList<string>? idStrings;
     private SortedDictionary<int, Node?>? auxNodes;
+    private SortedDictionary<int, GameBoxRefTable.File?>? extAuxNodes;
 
     public int? IdVersion { get; internal set; }
     public IList<string> IdStrings => idStrings ??= new List<string>();
     public SortedDictionary<int, Node?> AuxNodes => auxNodes ??= new();
+    public SortedDictionary<int, GameBoxRefTable.File?> ExtAuxNodes => extAuxNodes ??= new();
 
     public bool Encapsulated { get; }
 

--- a/Src/GBX.NET/Mat3.cs
+++ b/Src/GBX.NET/Mat3.cs
@@ -1,0 +1,8 @@
+﻿namespace GBX.NET;
+
+public readonly record struct Mat3(float XX, float XY, float XZ,
+                                   float YX, float YY, float YZ,
+                                   float ZX, float ZY, float ZZ)
+{
+    public static readonly Mat3 Zero = new();
+}

--- a/Src/GBX.NET/Mat4.cs
+++ b/Src/GBX.NET/Mat4.cs
@@ -5,5 +5,5 @@ public readonly record struct Mat4(float XX, float XY, float XZ, float XW,
                                    float ZX, float ZY, float ZZ, float ZW,
                                    float WX, float WY, float WZ, float WW)
 {
-    public static readonly Iso4 Zero = new();
+    public static readonly Mat4 Zero = new();
 }

--- a/Src/GBX.NET/Node.cs
+++ b/Src/GBX.NET/Node.cs
@@ -483,7 +483,7 @@ public abstract class Node
             }
             else
             {
-                await WriteChunkWithReadWriteAsync(node, (IReadableWritableChunk)chunk, gbxrw, cancellationToken);
+                await ReadWriteChunkAsync(node, (IReadableWritableChunk)chunk, gbxrw, cancellationToken);
             }
         }
         catch (EndOfStreamException) // May not be needed
@@ -802,13 +802,13 @@ public abstract class Node
             return;
         }
 
-        await WriteChunkWithReadWriteAsync(chunk, rw, cancellationToken);
+        await ReadWriteChunkAsync(chunk, rw, cancellationToken);
     }
 
-    private static async Task WriteChunkWithReadWriteAsync(Node node,
-                                                           IReadableWritableChunk chunk,
-                                                           GameBoxReaderWriter rw,
-                                                           CancellationToken cancellationToken)
+    private static async Task ReadWriteChunkAsync(Node node,
+                                                  IReadableWritableChunk chunk,
+                                                  GameBoxReaderWriter rw,
+                                                  CancellationToken cancellationToken)
     {
         if (NodeManager.IsAsyncChunk(chunk.Id))
         {
@@ -824,11 +824,11 @@ public abstract class Node
         chunk.ReadWrite(node, rw);
     }
 
-    private async Task WriteChunkWithReadWriteAsync(IReadableWritableChunk chunk,
-                                                    GameBoxReaderWriter rw,
-                                                    CancellationToken cancellationToken)
+    private async Task ReadWriteChunkAsync(IReadableWritableChunk chunk,
+                                           GameBoxReaderWriter rw,
+                                           CancellationToken cancellationToken)
     {
-        await WriteChunkWithReadWriteAsync(this, chunk, rw, cancellationToken);
+        await ReadWriteChunkAsync(this, chunk, rw, cancellationToken);
     }
 
     private void WriteSkippableChunk(ISkippableChunk skippableChunk,
@@ -894,7 +894,7 @@ public abstract class Node
 
         try
         {
-            await WriteChunkWithReadWriteAsync(skippableChunk, rw, cancellationToken);
+            await ReadWriteChunkAsync(skippableChunk, rw, cancellationToken);
         }
         catch (ChunkWriteNotImplementedException)
         {

--- a/Tests/GBX.NET.Tests/Unit/Engines/GameData/CGameCtnCollectorTests.cs
+++ b/Tests/GBX.NET.Tests/Unit/Engines/GameData/CGameCtnCollectorTests.cs
@@ -98,7 +98,7 @@ public class CGameCtnCollectorTests
             chunkTester.ReadWriteWithReader();
 
             // Assert
-            Assert.Equal(expected: new("", "Stadium", "bigbang1112"), actual: chunkTester.Node.Author);
+            Assert.Equal(expected: new("", "Stadium", "bigbang1112"), actual: chunkTester.Node.Ident);
         }
         
         [Fact]
@@ -113,7 +113,7 @@ public class CGameCtnCollectorTests
             chunkTester.ReadWriteWithReader();
 
             // Assert
-            Assert.Equal(expected: new("", new(26), "akPfIM0aSzuHuaaDWptBbQ"), actual: chunkTester.Node.Author);
+            Assert.Equal(expected: new("", new(26), "akPfIM0aSzuHuaaDWptBbQ"), actual: chunkTester.Node.Ident);
         }
 
         [Fact]
@@ -124,7 +124,7 @@ public class CGameCtnCollectorTests
                 = new(GameVersions.ManiaPlanet_Latest);
             chunkTester.SetIdState(version: 3);
 
-            chunkTester.Node.Author = new("", "Stadium", "bigbang1112");
+            chunkTester.Node.Ident = new("", "Stadium", "bigbang1112");
 
             // Act
             chunkTester.ReadWriteWithWriter();
@@ -141,7 +141,7 @@ public class CGameCtnCollectorTests
                 = new(GameVersions.Trackmania2020_2022_7_6);
             chunkTester.SetIdState(version: 3);
 
-            chunkTester.Node.Author = new("", new(26), "akPfIM0aSzuHuaaDWptBbQ");
+            chunkTester.Node.Ident = new("", new(26), "akPfIM0aSzuHuaaDWptBbQ");
 
             // Act
             chunkTester.ReadWriteWithWriter();

--- a/Tools/GbxExplorer/Client/Sections/SectionSocials.razor
+++ b/Tools/GbxExplorer/Client/Sections/SectionSocials.razor
@@ -20,10 +20,15 @@
 </div>
 
 @code {
-    private string branch = "master";
+    private string? branch;
 
     protected override void OnInitialized()
     {
         branch = Config["Branch"];
+
+        if (string.IsNullOrWhiteSpace(branch))
+        {
+            branch = "master";
+        }
     }
 }


### PR DESCRIPTION
- Added TM2020 and Shootmania input reading support
  - Accessible through `CGameCtnGhost.PlayerInputs.InputChanges`
  - `InputChange` was transformed into `TrackmaniaInputChange`
  - `ShootmaniaInputChange` was added for Shootmania inputs
  - Similarities are packed under `IInputChange`
- Added `CGameCtnMediaBlockTriangles3D.Create()`
- Added `CGameCtnDecorationSize.Size`
- Added `CSceneObject.Motion`
- Added `CPlugSolid` `SolidPreLightGen` and `FileWriteTime`
- Added `Mat3`
- Changed `CGameCtnCollector` `Author` to `Ident`
- Changed `CGameCtnGhost.Data` `NodeID` to `SavedMobilClassId`
- Fixed `CControlEffectSimi` on old maps (usually problematic with Randomizer TMF)
- Fixed NodeRef writing of external nodes
- Fixed many cases of `CPlugVisual3D`
- Fixed `CPlugSurface.Box` read/write
- Fixed other `CPlugSurface` problems
- Fixed `Mat4.Zero`

### GBX.NET Explorer

- Fixed GitHub link branch on the `master` build

### GBX.NET.PAK 1.1.2

- Added `NadeoPakFile.GetDirectoryName()`