### PR TITLE
Shootmania and TM2020 accurate input implementation

### DIFF
--- a/Src/GBX.NET/BitReader.cs
+++ b/Src/GBX.NET/BitReader.cs
@@ -21,11 +21,11 @@ public class BitReader
         return result;
     }
 
-    public long ReadNumber(int bits)
+    public ulong ReadNumber(int bits)
     {
-        var result = 0;
+        ulong result = 0;
         for (var i = 0; i < bits; i++)
-            result |= (ReadBit() ? 1 : 0) << i;
+            result |= (ulong)(ReadBit() ? 1 : 0) << i;
         return result;
     }
 

--- a/Src/GBX.NET/BitReader.cs
+++ b/Src/GBX.NET/BitReader.cs
@@ -1,0 +1,67 @@
+﻿namespace GBX.NET;
+
+public class BitReader
+{
+    private readonly byte[] data;
+
+    public int Position { get; private set; }
+    public int Length { get; }
+
+    public BitReader(byte[] data)
+    {
+        this.data = data;
+
+        Length = data.Length * 8;
+    }
+
+    public bool ReadBit()
+    {
+        var result = (data[Position / 8] & (1 << (Position % 8))) != 0;
+        Position++;
+        return result;
+    }
+
+    public int ReadNumber(int bits)
+    {
+        var result = 0;
+        for (var i = 0; i < bits; i++)
+            result |= (ReadBit() ? 1 : 0) << i;
+        return result;
+    }
+
+    public byte Read2Bit()
+    {
+        return (byte)ReadNumber(bits: 2);
+    }
+
+    public byte ReadByte()
+    {
+        return (byte)ReadNumber(bits: 8);
+    }
+
+    public sbyte ReadSByte()
+    {
+        return (sbyte)ReadNumber(bits: 8);
+    }
+
+    public short ReadInt16()
+    {
+        return (short)ReadNumber(bits: 16);
+    }
+
+    public int ReadInt32()
+    {
+        return ReadNumber(bits: 32);
+    }
+
+    // ReadToEnd through bits
+
+    public byte[] ReadToEnd()
+    {
+        var remaining = Length - Position;
+        var result = new byte[(remaining + 7) / 8];
+        for (var i = 0; i < remaining; i++)
+            result[i / 8] |= (byte)((ReadBit() ? 1 : 0) << (i % 8));
+        return result;
+    }
+}

--- a/Src/GBX.NET/BitReader.cs
+++ b/Src/GBX.NET/BitReader.cs
@@ -21,7 +21,7 @@ public class BitReader
         return result;
     }
 
-    public int ReadNumber(int bits)
+    public long ReadNumber(int bits)
     {
         var result = 0;
         for (var i = 0; i < bits; i++)
@@ -51,7 +51,7 @@ public class BitReader
 
     public int ReadInt32()
     {
-        return ReadNumber(bits: 32);
+        return (int)ReadNumber(bits: 32);
     }
 
     // ReadToEnd through bits

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -183,7 +183,7 @@ public partial class CGameCtnGhost
                     different = true;
                 }
 
-                if (i > 0) // This check is a bit weird, may not work for StormMan gameplay
+                if (i > 0 || sameMouse) // This check is a bit weird, may not work for StormMan gameplay
                 {
                     var sameValue = r.ReadBit();
 
@@ -201,13 +201,6 @@ public partial class CGameCtnGhost
                 {
                     yield return new TrackmaniaInputChange(i, states, mouseAccuX, mouseAccuY, steer, gas, brake);
                 }
-            }
-
-            var theRest = r.ReadToEnd();
-
-            if (theRest.Any(x => x != 0))
-            {
-                throw new Exception("Input buffer not cleared out completely");
             }
         }
 

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -187,7 +187,8 @@ public partial class CGameCtnGhost
                 // If starting with horn on, it is included on first tick
                 // If mouse is not plugged, it is also included
                 // In code, this check is presented as '(X - 2 & 0xfffffffd) == 0'
-                if ((i == 0 && ((states.GetValueOrDefault() & 64) != 0)) || sameMouse)
+
+                if (states.HasValue || i > 0)
                 {
                     var sameValue = r.ReadBit();
 
@@ -281,18 +282,7 @@ public partial class CGameCtnGhost
             public TimeInt32 Timestamp { get; } = new(Tick * 10);
 
             public bool? Respawn => States is null ? null : (States & 2147483648) != 0;
-            public bool? Horn
-            {
-                get
-                {
-                    if (States is null)
-                    {
-                        return null;
-                    }
-
-                    return (States & (ulong)(Tick == 0 ? 64 : 2)) != 0;
-                }
-            }
+            public bool? Horn => null;
         }
     }
 }

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -130,15 +130,9 @@ public partial class CGameCtnGhost
                     {
                         var onlyTriggerAndAction = r.ReadBit();
 
-                        if (onlyTriggerAndAction)
-                        {
-                            isAction = r.ReadBit();
-                            isGunTrigger = r.ReadBit();
-                        }
-                        else
-                        {
-                            states = r.ReadInt32();
-                        }
+                        states = onlyTriggerAndAction
+                            ? r.Read2Bit()
+                            : r.ReadInt32();
 
                         different = true;
                     }
@@ -146,7 +140,7 @@ public partial class CGameCtnGhost
 
                 if (different)
                 {
-                    yield return new ShootmaniaInputChange(i, mouseAccuX, mouseAccuY, strafe, walk, vertical, isAction, isGunTrigger, states);
+                    yield return new ShootmaniaInputChange(i, mouseAccuX, mouseAccuY, strafe, walk, vertical, states);
                 }
             }
 
@@ -191,16 +185,15 @@ public partial class CGameCtnGhost
                                                    EStrafe? Strafe,
                                                    EWalk? Walk,
                                                    byte? Vertical,
-                                                   bool? IsAction,
-                                                   bool? IsGunTrigger,
                                                    int? States) : IInputChange
         {
             public TimeInt32 Timestamp => new(Tick * 10);
 
+            public bool? IsGunTrigger => States is null ? null : (States & 2) != 0;
             public bool? FreeLook => States is null ? null : (States & 4) != 0;
             public bool? Camera2 => States is null ? null : (States & 32) != 0;
             public bool? Jump => States is null ? null : (States & 128) != 0;
-            public bool? Action => States is null ? null : (States & 257) != 0;
+            public bool? IsAction => States is null ? null : (States & 257) != 0;
             public bool? ActionSlot1 => States is null ? null : (States & 1024) != 0;
             public bool? ActionSlot2 => States is null ? null : (States & 2048) != 0;
             public bool? ActionSlot3 => States is null ? null : (States & 4096) != 0;

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -198,6 +198,7 @@ public partial class CGameCtnGhost
             public TimeInt32 Timestamp => new(Tick * 10);
 
             public bool? FreeLook => States is null ? null : (States & 4) != 0;
+            public bool? Camera2 => States is null ? null : (States & 32) != 0;
             public bool? Jump => States is null ? null : (States & 128) != 0;
             public bool? Action => States is null ? null : (States & 257) != 0;
             public bool? ActionSlot1 => States is null ? null : (States & 1024) != 0;

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -84,8 +84,6 @@ public partial class CGameCtnGhost
                 var strafe = default(EStrafe?);
                 var walk = default(EWalk?);
                 var vertical = default(byte?);
-                var isAction = default(bool?);
-                var isGunTrigger = default(bool?);
                 var states = default(int?);
 
                 var sameMouse = r.ReadBit();
@@ -157,12 +155,6 @@ public partial class CGameCtnGhost
             yield break;
         }
 
-        public interface IInputChange
-        {
-            int Tick { get; }
-            TimeInt32 Timestamp { get; }
-        }
-
         public enum EStrafe : byte
         {
             None,
@@ -179,6 +171,12 @@ public partial class CGameCtnGhost
             Backward
         }
 
+        public interface IInputChange
+        {
+            int Tick { get; }
+            TimeInt32 Timestamp { get; }
+        }
+
         public record struct ShootmaniaInputChange(int Tick,
                                                    short? MouseAccuX,
                                                    short? MouseAccuY,
@@ -191,6 +189,7 @@ public partial class CGameCtnGhost
 
             public bool? IsGunTrigger => States is null ? null : (States & 2) != 0;
             public bool? FreeLook => States is null ? null : (States & 4) != 0;
+            public bool? Fly => States is null ? null : (States & 8) != 0;
             public bool? Camera2 => States is null ? null : (States & 32) != 0;
             public bool? Jump => States is null ? null : (States & 128) != 0;
             public bool? IsAction => States is null ? null : (States & 257) != 0;


### PR DESCRIPTION
This pull request intends to implement Shootmania engine input handling from binary documentation of these (individual input tick states):

Shootmania:
```
bit SameMouse
if SameMouse == 0
    ushort MouseAccuX
    ushort MouseAccuY
else
    MouseAccuX = previous
    MouseAccuY = previous
bit SameValuesAfter
SameValue = SameValuesAfter
if SameValuesAfter == 0
    bit SameValue
if SameValue == 0
    2bit Strafe
    if Strafe == 2
        exception("'Strafe2 != 2' failed.")
    2bit Walk
    if Walk == 2
        exception("'Walk2 != 2' failed.")
    if _Version == 8
        2bit Vertical
        if Vertical == 2
            exception("'Vertical2 != 2' failed.")
if SameValuesAfter == 0
    bit SameValue
    if SameValue == 0
        bit OnlyGunTriggerAndAction
        if OnlyGunTriggerAndAction == 0
            uint StatesAsNat32
        else
            bit IsAction
            bit IsGunTrigger
```

TM2020:
```
bit SameState
if SameState== 0
    bit OnlySomething
    if OnlySomething != 0
        2bit
    else if _Version == 11
        33bit
    else if _Version == 12
        34bit
bit SameMouse
if SameMouse == 0
    ushort MouseAccuX
    ushort MouseAccuY
else
    MouseAccuX = previous
    MouseAccuY = previous
bit SameValue
if ([some var] - 2 & 0xfffffffd) == 0 # May not be necessary, always true in regular replays
    if SameValue == 0
        sbyte Steer
        bit Gas
        bit Brake
    else
        previous values
else if Tick > 0
    if SameValue == 0
        2bit Strafe
        2bit Walk
        2bit Vertical
        2bit Horiz
    else
        previous values
```