### PR TITLE
GBX.NET 1.1.2

### DIFF
--- a/Src/GBX.NET/Badge.cs
+++ b/Src/GBX.NET/Badge.cs
@@ -1,0 +1,36 @@
+﻿namespace GBX.NET;
+
+public class Badge : IReadableWritable
+{
+    private Vec3 color = (1, 1, 1);
+    private int? u01;
+    private string? u02;
+    private (string, string)[] stickers = Array.Empty<(string, string)>();
+    private string[] layers = Array.Empty<string>();
+
+    public Vec3 Color { get => color; set => color = value; }
+    public int? U01 { get => u01; set => u01 = value; }
+    public string? U02 { get => u02; set => u02 = value; }
+    public (string, string)[] Stickers { get => stickers; set => stickers = value; }
+    public string[] Layers { get => layers; set => layers = value; }
+
+    public void ReadWrite(GameBoxReaderWriter rw, int version = 0)
+    {
+        rw.Vec3(ref color);
+
+        if (version == 0)
+        {
+            rw.Int32(ref u01);
+            rw.String(ref u02);
+        }
+
+        rw.Array(ref stickers!, (i, r) => (r.ReadString(), r.ReadString()), // SSticker array
+        (x, w) =>
+        {
+            w.Write(x.Item1);
+            w.Write(x.Item2);
+        });
+
+        rw.ArrayString(ref layers!); // SLayer array
+    }
+}

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -4133,7 +4133,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
             var author = default(string?);
             var skin = default(CGameCtnBlockSkin?);
 
-            if (CGameCtnBlock.IsSkinnableBlock_WhenDefined(flags))
+            if (CGameCtnBlock.IsSkinnableBlock(flags))
             {
                 author = r.ReadId();
                 skin = r.ReadNodeRef<CGameCtnBlockSkin>();
@@ -4178,7 +4178,7 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
                 
                 w.Write(block.Flags);
 
-                if (CGameCtnBlock.IsSkinnableBlock_WhenDefined(block.Flags))
+                if (CGameCtnBlock.IsSkinnableBlock(block.Flags))
                 {
                     w.WriteId(block.Author);
                     w.Write(block.Skin);

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -4130,7 +4130,16 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
                 coord -= (0, 1, 0);
             }
 
-            n.BakedBlocks!.Add(new(name, direction, coord, flags));
+            var author = default(string?);
+            var skin = default(CGameCtnBlockSkin?);
+
+            if (CGameCtnBlock.IsSkinnableBlock_WhenDefined(flags))
+            {
+                author = r.ReadId();
+                skin = r.ReadNodeRef<CGameCtnBlockSkin>();
+            }
+
+            n.BakedBlocks!.Add(new(name, direction, coord, flags, author, skin));
 
             return flags;
         }
@@ -4168,6 +4177,12 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
                 w.Write((Byte3)coord);
                 
                 w.Write(block.Flags);
+
+                if (CGameCtnBlock.IsSkinnableBlock_WhenDefined(block.Flags))
+                {
+                    w.WriteId(block.Author);
+                    w.Write(block.Skin);
+                }
             }
 
             w.Write(U02);

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -443,6 +443,12 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     /// </summary>
     [NodeMember]
     [SupportsFormatting]
+    [AppliedWithChunk<Chunk03043001>(sinceVersion: 0, upToVersion: 0)]
+    [AppliedWithChunk<Chunk03043002>(sinceVersion: 0, upToVersion: 2)]
+    [AppliedWithChunk<Chunk03043003>]
+    [AppliedWithChunk<Chunk03043012>]
+    [AppliedWithChunk<Chunk03043013>]
+    [AppliedWithChunk<Chunk0304301F>]
     public string MapName { get => mapName; set => mapName = value; }
 
     /// <summary>

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -313,6 +313,12 @@ public partial class CGameCtnGhost
         {
             public TimeInt32 Timestamp { get; } = new(Tick * 10);
 
+            public bool? ActionSlot1 => States is null ? null : (States & 32896) != 0;
+            public bool? ActionSlot2 => States is null ? null : (States & 132096) != 0;
+            public bool? ActionSlot3 => States is null ? null : (States & 524288) != 0;
+            public bool? ActionSlot4 => States is null ? null : (States & 2097152) != 0;
+            public bool? ActionSlot5 => States is null ? null : (States & 8388608) != 0;
+
             public bool? Respawn => States is null ? null : (States & 2147483648) != 0;
             public bool? Horn
             {
@@ -331,6 +337,7 @@ public partial class CGameCtnGhost
                     return States == 2;
                 }
             }
+            
         }
     }
 }

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -312,14 +312,7 @@ public partial class CGameCtnGhost
                                                             bool? Brake) : IInputChange
         {
             public TimeInt32 Timestamp { get; } = new(Tick * 10);
-
-            public bool? ActionSlot1 => States is null ? null : (States & 32896) != 0;
-            public bool? ActionSlot2 => States is null ? null : (States & 132096) != 0;
-            public bool? ActionSlot3 => States is null ? null : (States & 524288) != 0;
-            public bool? ActionSlot4 => States is null ? null : (States & 2097152) != 0;
-            public bool? ActionSlot5 => States is null ? null : (States & 8388608) != 0;
-
-            public bool? Respawn => States is null ? null : (States & 2147483648) != 0;
+            
             public bool? Horn
             {
                 get
@@ -337,7 +330,15 @@ public partial class CGameCtnGhost
                     return States == 2;
                 }
             }
-            
+
+            public bool? FreeLook => States is null ? null : (States & 8192) != 0;
+            public bool? ActionSlot1 => States is null ? null : (States & 32896) != 0;
+            public bool? ActionSlot2 => States is null ? null : (States & 132096) != 0;
+            public bool? ActionSlot3 => States is null ? null : (States & 524288) != 0;
+            public bool? ActionSlot4 => States is null ? null : (States & 2097152) != 0;
+            public bool? ActionSlot5 => States is null ? null : (States & 8388608) != 0;
+            public bool? Respawn => States is null ? null : (States & 2147483648) != 0;
+            public bool? SecondaryRespawn => States is null ? null : (States & 8589934592) != 0;
         }
     }
 }

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.cs
@@ -450,14 +450,9 @@ public partial class CGameCtnGhost : CGameGhost
     public class Chunk03092000 : SkippableChunk<CGameCtnGhost>, IVersionable
     {
         private int version;
-
-        public Vec3 U01;
+        
         public bool U03;
         public int[]? U04;
-        public int U05;
-        public Vec3 U06;
-        public (string value, string key)[]? U07;
-        public string[]? U08;
 
         public int Version { get => version; set => version = value; }
 

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.cs
@@ -400,7 +400,7 @@ public partial class CGameCtnGhost : CGameGhost
     public string? GhostClubTag { get => ghostClubTag; set => ghostClubTag = value; }
 
     /// <summary>
-    /// These are the Shootmania and TM2020 inputs but don't get jump-excited, the values are unknown.
+    /// Shootmania and TM2020 inputs.
     /// </summary>
     [NodeMember]
     [AppliedWithChunk<Chunk0309201D>]

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.cs
@@ -25,7 +25,7 @@ public partial class CGameCtnGhost : CGameGhost
     private string? ghostUid;
     private TimeInt32? raceTime;
     private int? respawns;
-    private Vec3? lightTrailColor;
+    private Vec3 lightTrailColor = (1, 0, 0);
     private int? stuntScore;
     private Checkpoint[]? checkpoints;
     private TimeInt32 eventsDuration;
@@ -38,6 +38,8 @@ public partial class CGameCtnGhost : CGameGhost
     private string? validate_ChallengeUid;
     private string? validate_TitleId;
     private bool hasBadges;
+    private int? badgeVersion;
+    private Badge? badge;
     private string? skinFile;
     private string? ghostClubTag;
     private PlayerInputData[]? playerInputs;
@@ -174,7 +176,7 @@ public partial class CGameCtnGhost : CGameGhost
     [AppliedWithChunk<Chunk03092000>]
     [AppliedWithChunk<Chunk03092007>]
     [AppliedWithChunk<Chunk03092009>]
-    public Vec3? LightTrailColor
+    public Vec3 LightTrailColor
     {
         get
         {
@@ -395,6 +397,14 @@ public partial class CGameCtnGhost : CGameGhost
     public bool HasBadges { get => hasBadges; set => hasBadges = value; }
 
     [NodeMember]
+    [AppliedWithChunk<Chunk03092000>]
+    public int? BadgeVersion { get => badgeVersion; set => badgeVersion = value; }
+
+    [NodeMember]
+    [AppliedWithChunk<Chunk03092000>]
+    public Badge? Badge { get => badge; set => badge = value; }
+
+    [NodeMember]
     [SupportsFormatting]
     [AppliedWithChunk<Chunk03092000>(sinceVersion: 8)]
     public string? GhostClubTag { get => ghostClubTag; set => ghostClubTag = value; }
@@ -454,6 +464,8 @@ public partial class CGameCtnGhost : CGameGhost
         public override void ReadWrite(CGameCtnGhost n, GameBoxReaderWriter rw)
         {
             rw.Int32(ref version);
+            
+            // SGamePlayerMobilAppearanceParams::Archive
             rw.Ident(ref n.playerModel!);
             rw.Vec3(ref n.lightTrailColor);
             rw.ListFileRef(ref n.skinPackDescs);
@@ -461,17 +473,10 @@ public partial class CGameCtnGhost : CGameGhost
 
             if (n.hasBadges)
             {
-                rw.Int32(ref U05);
-                rw.Vec3(ref U06);
-                rw.Array(ref U07,
-                    (i, r) => (r.ReadString(), r.ReadString()),
-                    (x, w) =>
-                    {
-                        w.Write(x.Item1);
-                        w.Write(x.Item2);
-                    });
-                rw.ArrayString(ref U08);
+                rw.Int32(ref n.badgeVersion);
+                rw.Archive<Badge>(ref n.badge, n.badgeVersion.GetValueOrDefault()); // NGameBadge::BadgeArchive
             }
+            //
 
             rw.String(ref n.ghostNickname);
             rw.String(ref n.ghostAvatarName);

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockEntity.Key.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockEntity.Key.cs
@@ -1,0 +1,41 @@
+﻿namespace GBX.NET.Engines.Game;
+
+public partial class CGameCtnMediaBlockEntity
+{
+    public new class Key : CGameCtnMediaBlock.Key
+    {
+        private int u01;
+        private float u02;
+        private int u03;
+        private int u04;
+        private float u05;
+        private float? u06;
+
+        public int U01 { get => u01; set => u01 = value; }
+        public float U02 { get => u02; set => u02 = value; }
+        public int U03 { get => u03; set => u03 = value; }
+        public int U04 { get => u04; set => u04 = value; }
+        public float U05 { get => u05; set => u05 = value; }
+        public float? U06 { get => u06; set => u06 = value; }
+
+        public override void ReadWrite(GameBoxReaderWriter rw, int version = 0)
+        {
+            base.ReadWrite(rw, version);
+
+            rw.Int32(ref u01);
+
+            if (version >= 6)
+            {
+                rw.Single(ref u02);
+                rw.Int32(ref u03);
+                rw.Int32(ref u04);
+                rw.Single(ref u05);
+
+                if (version >= 7)
+                {
+                    rw.Single(ref u06);
+                }
+            }
+        }
+    }
+}

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockEntity.Key.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockEntity.Key.cs
@@ -4,36 +4,43 @@ public partial class CGameCtnMediaBlockEntity
 {
     public new class Key : CGameCtnMediaBlock.Key
     {
-        private int u01;
-        private float u02;
-        private int u03;
-        private int u04;
-        private float u05;
-        private float? u06;
+        public enum ELights
+        {
+            Auto,
+            On,
+            Off
+        }
+        
+        private ELights lights;
+        private float? u01;
+        private int? u02;
+        private int? u03;
+        private float trailIntensity = 1;
+        private float selfIllumIntensity = 1;
 
-        public int U01 { get => u01; set => u01 = value; }
-        public float U02 { get => u02; set => u02 = value; }
-        public int U03 { get => u03; set => u03 = value; }
-        public int U04 { get => u04; set => u04 = value; }
-        public float U05 { get => u05; set => u05 = value; }
-        public float? U06 { get => u06; set => u06 = value; }
+        public ELights Lights { get => lights; set => lights = value; }
+        public float? U01 { get => u01; set => u01 = value; }
+        public int? U02 { get => u02; set => u02 = value; }
+        public int? U03 { get => u03; set => u03 = value; }
+        public float TrailIntensity { get => trailIntensity; set => trailIntensity = value; }
+        public float SelfIllumIntensity { get => selfIllumIntensity; set => selfIllumIntensity = value; }
 
         public override void ReadWrite(GameBoxReaderWriter rw, int version = 0)
         {
             base.ReadWrite(rw, version);
 
-            rw.Int32(ref u01);
+            rw.EnumInt32<ELights>(ref lights);
 
             if (version >= 6)
             {
-                rw.Single(ref u02);
+                rw.Single(ref u01);
+                rw.Int32(ref u02);
                 rw.Int32(ref u03);
-                rw.Int32(ref u04);
-                rw.Single(ref u05);
+                rw.Single(ref trailIntensity);
 
                 if (version >= 7)
                 {
-                    rw.Single(ref u06);
+                    rw.Single(ref selfIllumIntensity);
                 }
             }
         }

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockEntity.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockEntity.cs
@@ -22,6 +22,8 @@ public partial class CGameCtnMediaBlockEntity : CGameCtnMediaBlock, CGameCtnMedi
     private IList<FileRef> skinNames = Array.Empty<FileRef>();
     private int? badgeVersion;
     private Badge? badge;
+    private string? skinOptions;
+    private string? ghostName;
 
     IEnumerable<CGameCtnMediaBlock.Key> IHasKeys.Keys
     {
@@ -101,6 +103,14 @@ public partial class CGameCtnMediaBlockEntity : CGameCtnMediaBlock, CGameCtnMedi
     [AppliedWithChunk<Chunk0329F000>(sinceVersion: 3)]
     public Badge? Badge { get => badge; set => badge = value; }
 
+    [NodeMember]
+    [AppliedWithChunk<Chunk0329F002>]
+    public string? SkinOptions { get => skinOptions; set => skinOptions = value; }
+
+    [NodeMember]
+    [AppliedWithChunk<Chunk0329F000>(sinceVersion: 7)]
+    public string? GhostName { get => ghostName; set => ghostName = value; }
+
     internal CGameCtnMediaBlockEntity()
     {
         recordData = null!;
@@ -178,7 +188,7 @@ public partial class CGameCtnMediaBlockEntity : CGameCtnMediaBlock, CGameCtnMedi
 
                         if (version >= 7)
                         {
-                            rw.String(ref U11);
+                            rw.String(ref n.ghostName);
 
                             if (version >= 8)
                             {
@@ -198,19 +208,17 @@ public partial class CGameCtnMediaBlockEntity : CGameCtnMediaBlock, CGameCtnMedi
 
     #endregion
 
-    #region 0x002 chunk
+    #region 0x002 chunk (SkinOptions)
 
     /// <summary>
-    /// CGameCtnMediaBlockEntity 0x002 chunk
+    /// CGameCtnMediaBlockEntity 0x002 chunk (SkinOptions)
     /// </summary>
-    [Chunk(0x0329F002)]
+    [Chunk(0x0329F002, "SkinOptions")]
     public class Chunk0329F002 : Chunk<CGameCtnMediaBlockEntity>
     {
-        public int U01;
-
         public override void ReadWrite(CGameCtnMediaBlockEntity n, GameBoxReaderWriter rw)
         {
-            rw.Int32(ref U01);
+            rw.String(ref n.skinOptions);
         }
     }
 

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockEntity.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockEntity.cs
@@ -5,13 +5,78 @@
 /// </summary>
 /// <remarks>ID: 0x0329F000</remarks>
 [Node(0x0329F000)]
-public class CGameCtnMediaBlockEntity : CGameCtnMediaBlock
+public class CGameCtnMediaBlockEntity : CGameCtnMediaBlock, CGameCtnMediaBlock.IHasTwoKeys
 {
     private CPlugEntRecordData recordData;
+    private TimeSingle start;
+    private TimeSingle end;
+    private TimeSingle startOffset;
+    private int[] noticeRecords = Array.Empty<int>();
+    private bool noDamage;
+    private bool forceLight;
+    private bool forceHue;
+    private Vec3 lightTrailColor = (1, 0, 0);
+    private Ident? playerModel;
+    private bool hasBadges;
+    private IList<FileRef> skinNames = Array.Empty<FileRef>();
+    private int? badgeVersion;
+    private Badge? badge;
+
+    [NodeMember(ExactName = "EntRecordData")]
+    [AppliedWithChunk<Chunk0329F000>]
+    public CPlugEntRecordData RecordData { get => recordData; set => recordData = value; }
 
     [NodeMember]
     [AppliedWithChunk<Chunk0329F000>]
-    public CPlugEntRecordData RecordData { get => recordData; set => recordData = value; }
+    public TimeSingle Start { get => start; set => start = value; }
+
+    [NodeMember]
+    [AppliedWithChunk<Chunk0329F000>]
+    public TimeSingle End { get => end; set => end = value; }
+
+    [NodeMember]
+    [AppliedWithChunk<Chunk0329F000>]
+    public TimeSingle StartOffset { get => startOffset; set => startOffset = value; }
+
+    [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk<Chunk0329F000>]
+    public int[] NoticeRecords { get => noticeRecords; set => noticeRecords = value; }
+
+    [NodeMember]
+    [AppliedWithChunk<Chunk0329F000>(sinceVersion: 2)]
+    public bool NoDamage { get => noDamage; set => noDamage = value; }
+
+    [NodeMember]
+    [AppliedWithChunk<Chunk0329F000>(sinceVersion: 2)]
+    public bool ForceLight { get => forceLight; set => forceLight = value; }
+
+    [NodeMember]
+    [AppliedWithChunk<Chunk0329F000>(sinceVersion: 2)]
+    public bool ForceHue { get => forceHue; set => forceHue = value; }
+    
+    [NodeMember]
+    [AppliedWithChunk<Chunk0329F000>(sinceVersion: 2)]
+    public Vec3 LightTrailColor { get => lightTrailColor; set => lightTrailColor = value; }
+
+    [NodeMember]
+    [AppliedWithChunk<Chunk0329F000>(sinceVersion: 3)]
+    public Ident? PlayerModel { get => playerModel; set => playerModel = value; }
+
+    [NodeMember]
+    [AppliedWithChunk<Chunk0329F000>(sinceVersion: 3)]
+    public IList<FileRef> SkinNames { get => skinNames; set => skinNames = value; }
+
+    [NodeMember]
+    [AppliedWithChunk<Chunk0329F000>(sinceVersion: 3)]
+    public bool HasBadges { get => hasBadges; set => hasBadges = value; }
+
+    [NodeMember]
+    [AppliedWithChunk<Chunk0329F000>(sinceVersion: 3)]
+    public int? BadgeVersion { get => badgeVersion; set => badgeVersion = value; }
+    
+    [NodeMember]
+    [AppliedWithChunk<Chunk0329F000>(sinceVersion: 3)]
+    public Badge? Badge { get => badge; set => badge = value; }
 
     internal CGameCtnMediaBlockEntity()
     {
@@ -30,18 +95,8 @@ public class CGameCtnMediaBlockEntity : CGameCtnMediaBlock
     {
         private int version;
 
-        public Vec3 U01;
-        public int[]? U02;
-        public bool? U03;
         public bool? U04;
-        public bool? U05;
-        public bool? U06;
-        public Vec3? U07;
-        public Ident? U08;
         public Vec3? U09;
-        public FileRef[]? U10;
-        public bool? U11;
-        public int? U12;
         public Vec3 U13;
         public int U14;
         public string? U15;
@@ -61,46 +116,33 @@ public class CGameCtnMediaBlockEntity : CGameCtnMediaBlock
                 return;
             }
 
-            rw.Vec3(ref U01);
-            rw.Array<int>(ref U02);
+            rw.TimeSingle(ref n.start); // according to getters setters
+            rw.TimeSingle(ref n.end); // according to getters setters
+            rw.TimeSingle(ref n.startOffset);
+            rw.Array<int>(ref n.noticeRecords!); // SPlugEntRecord array
 
             if (version >= 2)
             {
-                rw.Boolean(ref U03);
+                rw.Boolean(ref n.noDamage); // ComputeDamageStatesFromDamageZoneAmounts?
                 rw.Boolean(ref U04);
-                rw.Boolean(ref U05);
-                rw.Boolean(ref U06);
-                rw.Vec3(ref U07);
+                rw.Boolean(ref n.forceLight);
+                rw.Boolean(ref n.forceHue);
+                rw.Vec3(ref n.lightTrailColor);
 
                 if (version >= 3)
                 {
-                    rw.Ident(ref U08);
-                    rw.Vec3(ref U09);
-                    rw.Array(ref U10, r => r.ReadFileRef(), (x, w) => w.Write(x)); // array of PackDesc?
-                    rw.Boolean(ref U11);
+                    // SGamePlayerMobilAppearanceParams::Archive
+                    rw.Ident(ref n.playerModel);
+                    rw.Vec3(ref U09); // some rgb
+                    rw.ListFileRef(ref n.skinNames!); // Name assumed from getter
+                    rw.Boolean(ref n.hasBadges);
 
-                    if (U11 == true)
+                    if (n.hasBadges)
                     {
-                        rw.Int32(ref U12);
-
-                        // NGameBadge::BadgeArchive
-                        rw.Vec3(ref U13);
-
-                        if (U12 == 0)
-                        {
-                            rw.Int32(ref U14);
-                            rw.String(ref U15);
-                        }
-
-                        rw.Array(ref U16, (i, r) => (r.ReadString(), r.ReadString()),
-                        (x, w) =>
-                        {
-                            w.Write(x.Item1);
-                            w.Write(x.Item2);
-                        });
-
-                        rw.ArrayString(ref U17);
+                        rw.Int32(ref n.badgeVersion);
+                        rw.Archive<Badge>(ref n.badge, n.badgeVersion.GetValueOrDefault()); // NGameBadge::BadgeArchive
                     }
+                    //
                 }
             }
         }

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockEntity.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockEntity.cs
@@ -39,7 +39,7 @@ public class CGameCtnMediaBlockEntity : CGameCtnMediaBlock
         public Vec3? U07;
         public Ident? U08;
         public Vec3? U09;
-        public int? U10;
+        public FileRef[]? U10;
         public bool? U11;
         public int? U12;
         public Vec3 U13;
@@ -76,7 +76,7 @@ public class CGameCtnMediaBlockEntity : CGameCtnMediaBlock
                 {
                     rw.Ident(ref U08);
                     rw.Vec3(ref U09);
-                    rw.Int32(ref U10); // array of PackDesc?
+                    rw.Array(ref U10, r => r.ReadFileRef(), (x, w) => w.Write(x)); // array of PackDesc?
                     rw.Boolean(ref U11);
 
                     if (U11 == true)

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockEntity.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockEntity.cs
@@ -97,11 +97,6 @@ public class CGameCtnMediaBlockEntity : CGameCtnMediaBlock, CGameCtnMediaBlock.I
 
         public bool? U04;
         public Vec3? U09;
-        public Vec3 U13;
-        public int U14;
-        public string? U15;
-        public (string, string)[]? U16;
-        public string[]? U17;
 
         public int Version { get => version; set => version = value; }
 

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockEntity.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockEntity.cs
@@ -5,7 +5,7 @@
 /// </summary>
 /// <remarks>ID: 0x0329F000</remarks>
 [Node(0x0329F000)]
-public class CGameCtnMediaBlockEntity : CGameCtnMediaBlock, CGameCtnMediaBlock.IHasTwoKeys, CGameCtnMediaBlock.IHasKeys
+public partial class CGameCtnMediaBlockEntity : CGameCtnMediaBlock, CGameCtnMediaBlock.IHasTwoKeys, CGameCtnMediaBlock.IHasKeys
 {
     private CPlugEntRecordData recordData;
     private TimeSingle? start;
@@ -184,9 +184,9 @@ public class CGameCtnMediaBlockEntity : CGameCtnMediaBlock, CGameCtnMediaBlock.I
                             {
                                 rw.Int32(ref U12);
 
-                                if (version >= 9)
+                                if (version >= 10)
                                 {
-                                    rw.UntilFacade(Unknown); // Temporary
+                                    throw new ChunkVersionNotSupportedException(version);
                                 }
                             }
                         }
@@ -198,35 +198,23 @@ public class CGameCtnMediaBlockEntity : CGameCtnMediaBlock, CGameCtnMediaBlock.I
 
     #endregion
 
-    #endregion
+    #region 0x002 chunk
 
-    public new class Key : CGameCtnMediaBlock.Key
+    /// <summary>
+    /// CGameCtnMediaBlockEntity 0x002 chunk
+    /// </summary>
+    [Chunk(0x0329F002)]
+    public class Chunk0329F002 : Chunk<CGameCtnMediaBlockEntity>
     {
-        private int u01;
-        private int u02;
-        private int u03;
-        private int u04;
-        private int u05;
+        public int U01;
 
-        public int U01 { get => u01; set => u01 = value; }
-        public int U02 { get => u02; set => u02 = value; }
-        public int U03 { get => u03; set => u03 = value; }
-        public int U04 { get => u04; set => u04 = value; }
-        public int U05 { get => u05; set => u05 = value; }
-
-        public override void ReadWrite(GameBoxReaderWriter rw, int version = 0)
+        public override void ReadWrite(CGameCtnMediaBlockEntity n, GameBoxReaderWriter rw)
         {
-            base.ReadWrite(rw, version);
-
-            rw.Int32(ref u01);
-
-            if (version >= 6)
-            {
-                rw.Int32(ref u02);
-                rw.Int32(ref u03);
-                rw.Int32(ref u04);
-                rw.Int32(ref u05);
-            }
+            rw.Int32(ref U01);
         }
     }
+
+    #endregion
+
+    #endregion
 }

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockSpectators.Key.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockSpectators.Key.cs
@@ -1,0 +1,17 @@
+﻿namespace GBX.NET.Engines.Game;
+
+public partial class CGameCtnMediaBlockSpectators
+{
+    public new class Key : CGameCtnMediaBlock.Key
+    {
+        private float spectators;
+
+        public float Spectators { get => spectators; set => spectators = value; }
+
+        public override void ReadWrite(GameBoxReaderWriter rw, int version = 0)
+        {
+            base.ReadWrite(rw, version);
+            rw.Single(ref spectators);
+        }
+    }
+}

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockSpectators.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockSpectators.cs
@@ -1,0 +1,42 @@
+﻿namespace GBX.NET.Engines.Game;
+
+/// <remarks>ID: 0x030EB000</remarks>
+[Node(0x030EB000)]
+public partial class CGameCtnMediaBlockSpectators : CGameCtnMediaBlock, CGameCtnMediaBlock.IHasKeys
+{
+    private IList<Key> keys = Array.Empty<Key>();
+
+    IEnumerable<CGameCtnMediaBlock.Key> IHasKeys.Keys
+    {
+        get => keys.Cast<CGameCtnMediaBlock.Key>();
+        set => keys = value.Cast<Key>().ToList();
+    }
+
+    [NodeMember]
+    [AppliedWithChunk<Chunk030EB000>]
+    public IList<Key> Keys { get => keys; set => keys = value; }
+
+    internal CGameCtnMediaBlockSpectators()
+    {
+
+    }
+
+    #region 0x000 chunk
+
+    /// <summary>
+    /// CGameCtnMediaBlockSpectators 0x000 chunk
+    /// </summary>
+    [Chunk(0x030EB000)]
+    public class Chunk030EB000 : Chunk<CGameCtnMediaBlockSpectators>, IVersionable
+    {
+        public int Version { get; set; }
+
+        public override void ReadWrite(CGameCtnMediaBlockSpectators n, GameBoxReaderWriter rw)
+        {
+            rw.VersionInt32(this);
+            rw.ListKey(ref n.keys!);
+        }
+    }
+
+    #endregion
+}

--- a/Src/GBX.NET/Engines/Game/CGameCtnReplayRecord.InterfaceScriptInfo.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnReplayRecord.InterfaceScriptInfo.cs
@@ -1,0 +1,6 @@
+﻿namespace GBX.NET.Engines.Game;
+
+public partial class CGameCtnReplayRecord
+{
+    public record InterfaceScriptInfo(string[] U01, int U02);
+}

--- a/Src/GBX.NET/Engines/GameData/CGameCtnCollector.cs
+++ b/Src/GBX.NET/Engines/GameData/CGameCtnCollector.cs
@@ -373,12 +373,11 @@ public partial class CGameCtnCollector : CMwNod, CGameCtnCollector.IHeader
     [Chunk(0x2E001008)]
     public class Chunk2E001008 : Chunk<CGameCtnCollector>
     {
-        public byte U01;
+        public Node? U01;
 
         public override void ReadWrite(CGameCtnCollector n, GameBoxReaderWriter rw)
         {
-            rw.Byte(ref U01); // 0
-            rw.String(ref n.skinDirectory);
+            rw.NodeRef(ref U01);
         }
     }
 

--- a/Src/GBX.NET/Engines/GameData/CGameItemModel.cs
+++ b/Src/GBX.NET/Engines/GameData/CGameItemModel.cs
@@ -660,20 +660,32 @@ public partial class CGameItemModel : CGameCtnCollector, CGameItemModel.IHeader 
         public override void ReadWrite(CGameItemModel n, GameBoxReaderWriter rw)
         {
             rw.Int32(ref version);
-            rw.String(ref n.archetypeRef!);
 
-            if (n.archetypeRef.Length == 0)
+            if (version < 3)
             {
-                rw.Int32(ref U01);
+                throw new ChunkVersionNotSupportedException(version);
             }
 
-            if (version >= 6)
+            if (version >= 2)
             {
-                rw.String(ref U02); // SkinDirNameCustom
+                rw.String(ref n.archetypeRef!);
 
-                if (version >= 7)
+                if (version >= 5)
                 {
-                    rw.Int32(ref U03); // -1
+                    if (n.archetypeRef.Length == 0)
+                    {
+                        rw.Int32(ref U01);
+                    }
+
+                    if (version >= 6)
+                    {
+                        rw.String(ref U02); // SkinDirNameCustom
+
+                        if (version >= 7)
+                        {
+                            rw.Int32(ref U03); // -1
+                        }
+                    }
                 }
             }
         }
@@ -816,6 +828,33 @@ public partial class CGameItemModel : CGameCtnCollector, CGameItemModel.IHeader 
         {
             rw.Int32(ref version);
             rw.Int32(ref U02); // SItemGroupElement array with Iso4 and CMwNodDataRef
+        }
+    }
+
+    #endregion
+    
+    #region 0x022 skippable chunk
+
+    /// <summary>
+    /// CGameItemModel 0x022 skippable chunk
+    /// </summary>
+    [Chunk(0x2E002022)]
+    public class Chunk2E002022 : SkippableChunk<CGameItemModel>, IVersionable
+    {
+        private int version;
+        
+        public string[]? U01;
+        public ushort[]? U02;
+
+        public int Version { get => version; set => version = value; }
+
+        public override void ReadWrite(CGameItemModel n, GameBoxReaderWriter rw)
+        {
+            rw.Int32(ref version);
+            rw.Int32(10);
+            rw.ArrayId(ref U01);
+            rw.Int32(10);
+            rw.Array<ushort>(ref U02);
         }
     }
 

--- a/Src/GBX.NET/Engines/GameData/CGameObjectPhyModel.cs
+++ b/Src/GBX.NET/Engines/GameData/CGameObjectPhyModel.cs
@@ -190,6 +190,7 @@ public class CGameObjectPhyModel : CMwNod
         public CMwNod? U28;
         public CMwNod? U29;
         public CMwNod? U30;
+        public GameBoxRefTable.File? U30File;
         public CMwNod? U31;
         public CMwNod? U32;
 
@@ -201,7 +202,7 @@ public class CGameObjectPhyModel : CMwNod
 
             if (version < 11)
             {
-                rw.NodeRef(ref U30); // MoveShape
+                rw.NodeRef(ref U30, ref U30File); // MoveShape
                 rw.NodeRef(ref U31); // HitShape
                 rw.NodeRef(ref U32); // TriggerShape
             }

--- a/Src/GBX.NET/Engines/GameData/CGameObjectVisModel.cs
+++ b/Src/GBX.NET/Engines/GameData/CGameObjectVisModel.cs
@@ -194,6 +194,7 @@ public class CGameObjectVisModel : CMwNod
         public float? U12;
         public CMwNod? U13;
         public CMwNod? U14;
+        public GameBoxRefTable.File? U14File;
         public CMwNod? U15;
         public CMwNod? U16;
         public GameBoxRefTable.File? U16File;
@@ -207,15 +208,16 @@ public class CGameObjectVisModel : CMwNod
 
             if (version < 9)
             {
-                rw.NodeRef(ref U14);
-                rw.NodeRef(ref U15);
+                rw.NodeRef(ref U14, ref U14File);
             }
-
-            rw.String(ref n.mesh);
-
-            if (string.IsNullOrEmpty(n.mesh))
+            else
             {
-                rw.NodeRef<CPlugSolid2Model>(ref n.meshShaded, ref n.meshShadedFile);
+                rw.String(ref n.mesh);
+
+                if (string.IsNullOrEmpty(n.mesh))
+                {
+                    rw.NodeRef<CPlugSolid2Model>(ref n.meshShaded, ref n.meshShadedFile);
+                }
             }
 
             if (version < 18) // CPlugParticleEmitterModel?
@@ -225,10 +227,15 @@ public class CGameObjectVisModel : CMwNod
 
             if (version >= 2)
             {
-                rw.NodeRef<CPlugAnimLocSimple>(ref n.locAnim);
-            }
+                if (version < 9)
+                {
+                    rw.String(ref n.mesh);
+                }
 
-            rw.Int32(ref U03); // SPlugLightBallStateSimple array
+                rw.NodeRef<CPlugAnimLocSimple>(ref n.locAnim);
+
+                rw.Int32(ref U03); // SPlugLightBallStateSimple array
+            }
 
             if (version < 17)
             {

--- a/Src/GBX.NET/Engines/Plug/CPlugSolid2Model.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugSolid2Model.cs
@@ -336,27 +336,27 @@ public class CPlugSolid2Model : CMwNod
 
     public class ShadedGeom : IReadableWritable
     {
-        private int u01;
-        private int u02;
+        private int visualIndex;
+        private int materialIndex;
         private int u03;
-        private int? u04;
+        private int? lod;
         private int? u05;
 
-        public int U01 { get => u01; set => u01 = value; }
-        public int U02 { get => u02; set => u02 = value; }
+        public int VisualIndex { get => visualIndex; set => visualIndex = value; }
+        public int MaterialIndex { get => materialIndex; set => materialIndex = value; }
         public int U03 { get => u03; set => u03 = value; }
-        public int? U04 { get => u04; set => u04 = value; }
+        public int? Lod { get => lod; set => lod = value; }
         public int? U05 { get => u05; set => u05 = value; }
 
         public void ReadWrite(GameBoxReaderWriter rw, int version = 0)
         {
-            rw.Int32(ref u01);
-            rw.Int32(ref u02);
+            rw.Int32(ref visualIndex);
+            rw.Int32(ref materialIndex);
             rw.Int32(ref u03);
 
             if (version >= 1)
             {
-                rw.Int32(ref u04);
+                rw.Int32(ref lod, defaultValue: -1);
 
                 if (version >= 32)
                 {

--- a/Src/GBX.NET/Engines/Plug/CPlugSpriteParam.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugSpriteParam.cs
@@ -3,8 +3,73 @@
 [Node(0x090AC000)]
 public class CPlugSpriteParam : CPlug
 {
-	internal CPlugSpriteParam()
-	{
+    private Vec3 globalDirection;
+    private Vec2 pivotPoint;
+    private float globalDirTiltFactor;
+    private float textureHeightInWorld;
+    private float visibleMaxDistAtFov90;
+    private float visibleMinScreenHeight01;
 
-	}
+    public Vec3 GlobalDirection { get => globalDirection; set => globalDirection = value; }
+    public Vec2 PivotPoint { get => pivotPoint; set => pivotPoint = value; }
+    public float GlobalDirTiltFactor { get => globalDirTiltFactor; set => globalDirTiltFactor = value; }
+    public float TextureHeightInWorld { get => textureHeightInWorld; set => textureHeightInWorld = value; }
+    public float VisibleMaxDistAtFov90 { get => visibleMaxDistAtFov90; set => visibleMaxDistAtFov90 = value; }
+    public float VisibleMinScreenHeight01 { get => visibleMinScreenHeight01; set => visibleMinScreenHeight01 = value; }
+
+    internal CPlugSpriteParam()
+    {
+
+    }
+
+    #region 0x000 chunk
+
+    /// <summary>
+    /// CPlugSpriteParam 0x000 chunk
+    /// </summary>
+    [Chunk(0x090AC000)]
+    public class Chunk090AC000 : Chunk<CPlugSpriteParam>
+    {
+        public uint U01;
+
+        public override void ReadWrite(CPlugSpriteParam n, GameBoxReaderWriter rw)
+        {
+            rw.UInt32(ref U01); // DoData
+            rw.Vec3(ref n.globalDirection);
+            rw.Vec2(ref n.pivotPoint);
+            rw.Single(ref n.globalDirTiltFactor);
+        }
+    }
+
+    #endregion
+
+    #region 0x001 chunk
+
+    /// <summary>
+    /// CPlugSpriteParam 0x001 chunk
+    /// </summary>
+    [Chunk(0x090AC001)]
+    public class Chunk090AC001 : Chunk090AC000, IVersionable
+    {
+        private int version;
+
+        public int Version { get => version; set => version = value; }
+
+        public override void ReadWrite(CPlugSpriteParam n, GameBoxReaderWriter rw)
+        {
+            rw.Int32(ref version);
+            
+            base.ReadWrite(n, rw);
+
+            rw.Single(ref n.textureHeightInWorld);
+
+            if (version >= 1)
+            {
+                rw.Single(ref n.visibleMaxDistAtFov90);
+                rw.Single(ref n.visibleMinScreenHeight01);
+            }
+        }
+    }
+
+    #endregion
 }

--- a/Src/GBX.NET/Engines/Plug/CPlugVisual3D.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugVisual3D.cs
@@ -1,7 +1,7 @@
 ﻿namespace GBX.NET.Engines.Plug;
 
 /// <remarks>ID: 0x0902C000</remarks>
-[Node(0x0902C000), WritingNotSupported]
+[Node(0x0902C000)]
 public abstract class CPlugVisual3D : CPlugVisual
 {
     private Vertex[] vertices;

--- a/Src/GBX.NET/Engines/Plug/CPlugVisualSprite.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugVisualSprite.cs
@@ -4,6 +4,12 @@
 [Node(0x09010000)]
 public class CPlugVisualSprite : CPlugVisual3D
 {
+    private CPlugSpriteParam? spriteParam;
+
+    [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk<Chunk09010008>]
+    public CPlugSpriteParam? SpriteParam { get => spriteParam; set => spriteParam = value; }
+
     internal CPlugVisualSprite()
     {
 
@@ -48,4 +54,50 @@ public class CPlugVisualSprite : CPlugVisual3D
             rw.Int16(ref U02);
         }
     }
+
+    #region 0x008 chunk
+
+    /// <summary>
+    /// CPlugVisualSprite 0x008 chunk
+    /// </summary>
+    [Chunk(0x09010008)]
+    public class Chunk09010008 : Chunk<CPlugVisualSprite>
+    {
+        public override void Read(CPlugVisualSprite n, GameBoxReader r)
+        {
+            n.spriteParam = Parse<CPlugSpriteParam>(r, 0x090AC000, progress: null, ignoreZeroIdChunk: true); // direct node
+        }
+
+        public override void Write(CPlugVisualSprite n, GameBoxWriter w)
+        {
+            if (n.spriteParam is null)
+            {
+                w.Write(0);
+            }
+            else
+            {
+                n.spriteParam.Write(w);
+            }
+        }
+    }
+
+    #endregion
+
+    #region 0x009 chunk
+
+    /// <summary>
+    /// CPlugVisualSprite 0x009 chunk
+    /// </summary>
+    [Chunk(0x09010009)]
+    public class Chunk09010009 : Chunk<CPlugVisualSprite>
+    {
+        public Rect[]? U01;
+
+        public override void ReadWrite(CPlugVisualSprite n, GameBoxReaderWriter rw)
+        {
+            rw.Array<Rect>(ref U01);
+        }
+    }
+
+    #endregion
 }

--- a/Src/GBX.NET/GameBoxHeader.cs
+++ b/Src/GBX.NET/GameBoxHeader.cs
@@ -60,7 +60,7 @@ public class GameBoxHeader
     {
         var headerChunks = (node as INodeHeader)?.HeaderChunks ?? HeaderChunks;
 
-        if (headerChunks is null)
+        if (headerChunks is null || headerChunks.Count == 0)
         {
             w.Write(0);
             return;

--- a/Src/GBX.NET/Node.cs
+++ b/Src/GBX.NET/Node.cs
@@ -683,7 +683,7 @@ public abstract class Node
         WriteFacade(w);
     }
 
-    public async Task WriteAsync(GameBoxWriter w, CancellationToken cancellationToken)
+    internal async Task WriteAsync(GameBoxWriter w, CancellationToken cancellationToken)
     {
         var stopwatch = Stopwatch.StartNew();
 

--- a/Src/GBX.NET/Resources/ClassID.txt
+++ b/Src/GBX.NET/Resources/ClassID.txt
@@ -377,7 +377,7 @@
   0E8 CGameManialinkFileEntry
   0E9 CGameNetDataDownload
   0EA CGameCampaignPlayerScores
-  0EB CGameLoadProgress
+  0EB CGameCtnMediaBlockSpectators
   0EC CGameNetFormBuddy
   0ED CGameLadderScoresComputer
   0EE CGameLadderScores

--- a/Tools/GbxExplorer/Client/Components/NodeTree.razor
+++ b/Tools/GbxExplorer/Client/Components/NodeTree.razor
@@ -11,7 +11,7 @@
 
 <ul style="margin-left: @(Depth == 0 ? "0" : "1.5")rem;@(Depth == 0 ? " width: calc(100% - 1rem);" : "")">
         
-    @if (ParentValueRenderer?.PreferProperties == false && ParentProperty is not null && Object is IEnumerable enumerable)
+    @if (ParentValueRenderer?.PreferProperties == false && Object is IEnumerable enumerable)
     {
         //cachedList ??= ;
 

--- a/Tools/GbxExplorer/Client/Components/NodeTree.razor
+++ b/Tools/GbxExplorer/Client/Components/NodeTree.razor
@@ -10,7 +10,62 @@
 }
 
 <ul style="margin-left: @(Depth == 0 ? "0" : "1.5")rem;@(Depth == 0 ? " width: calc(100% - 1rem);" : "")">
-        
+
+    @{
+    // This should be more flexible, and grouped by declaring type
+    var declaringTypeGroups = Properties
+        .OrderBy(x => x.Name)
+        .GroupBy(x => x.DeclaringType ?? throw new Exception("Declaring type is null"))
+        .ToDictionary(x => x.Key);
+
+    var sameDeclaringTypes = true;
+    var tempDeclaringType = default(Type);
+
+    foreach (var group in declaringTypeGroups)
+    {
+        if (tempDeclaringType is null)
+        {
+            tempDeclaringType = group.Key.DeclaringType;
+        }
+        else
+        {
+            if (tempDeclaringType != group.Key.DeclaringType)
+            {
+                sameDeclaringTypes = false;
+                break;
+            }
+        }
+    }
+
+    var type = Object.GetType();
+    }
+
+    @while (type.BaseType is not null)
+    {
+        if (!declaringTypeGroups.TryGetValue(type, out var group))
+        {
+            type = type.BaseType;
+            continue;
+        }
+
+        if (declaringTypeGroups.Count > 1)
+        {
+            <li class="declaringType">
+                @(sameDeclaringTypes || group.Key?.DeclaringType is null ? "" : $"{group.Key.DeclaringType.Name}.")@group.Key?.Name
+            </li>
+        }
+
+        foreach (var prop in group)
+        {
+            <li>
+                <!-- Sends the property with its object owner to the tree branch, copying the depth. -->
+                <NodeTreeElement Depth="Depth" Property="prop" Owner="Object" Tree="this"></NodeTreeElement>
+            </li>
+        }
+            
+        type = type.BaseType;
+    }
+
     @if (ParentValueRenderer?.PreferProperties == false && Object is IEnumerable enumerable)
     {
         //cachedList ??= ;
@@ -21,61 +76,6 @@
                 <NodeTreeElement Depth="Depth" Value="item.x" Id="item.i" Tree="this" />
             </li>
         </Virtualize>
-    }
-    else // In case of a regular property
-    {
-        // This should be more flexible, and grouped by declaring type
-        var declaringTypeGroups = Properties
-            .OrderBy(x => x.Name)
-            .GroupBy(x => x.DeclaringType ?? throw new Exception("Declaring type is null"))
-            .ToDictionary(x => x.Key);
-
-        var sameDeclaringTypes = true;
-        var tempDeclaringType = default(Type);
-
-        foreach (var group in declaringTypeGroups)
-        {
-            if (tempDeclaringType is null)
-            {
-                tempDeclaringType = group.Key.DeclaringType;
-            }
-            else
-            {
-                if (tempDeclaringType != group.Key.DeclaringType)
-                {
-                    sameDeclaringTypes = false;
-                    break;
-                }
-            }
-        }
-
-        var type = Object.GetType();
-
-        while (type.BaseType is not null)
-        {
-            if (!declaringTypeGroups.TryGetValue(type, out var group))
-            {
-                type = type.BaseType;
-                continue;
-            }
-
-            if (declaringTypeGroups.Count > 1)
-            {
-                <li class="declaringType">
-                    @(sameDeclaringTypes || group.Key?.DeclaringType is null ? "" : $"{group.Key.DeclaringType.Name}.")@group.Key?.Name
-                </li>
-            }
-
-            foreach (var prop in group)
-            {
-                <li>
-                    <!-- Sends the property with its object owner to the tree branch, copying the depth. -->
-                    <NodeTreeElement Depth="Depth" Property="prop" Owner="Object" Tree="this"></NodeTreeElement>
-                </li>
-            }
-            
-            type = type.BaseType;
-        }
     }
         
 </ul>

--- a/Tools/GbxExplorer/Client/Components/NodeTreeElement.razor
+++ b/Tools/GbxExplorer/Client/Components/NodeTreeElement.razor
@@ -120,6 +120,7 @@
     @{
         var props = Enumerable.Empty<PropertyInfo>();
         var collection = value as ICollection;
+        var enumerable = value as IEnumerable;
     }
 
     </span>
@@ -131,7 +132,7 @@
             .Where(x => x.GetGetMethod()?.IsStatic == false)
             .Where(ValueRenderer.ShowPropertyInTree);
 
-        if ((ValueRenderer.PreferProperties == false && collection?.Count > 0) || (collection is null && props.Any()))
+        if ((ValueRenderer.PreferProperties == false && (collection?.Count > 0 || enumerable?.OfType<object>().Any() == true)) || (collection is null && props.Any()))
         {
             <span class="member-name @(isNotIncluded ? "not-included-member" : "")" @onclick="async () => await OnExpandAsync()">
 

--- a/Tools/GbxExplorer/Client/Components/ValueRenderers/EnumerableValueRenderer.razor
+++ b/Tools/GbxExplorer/Client/Components/ValueRenderers/EnumerableValueRenderer.razor
@@ -26,5 +26,9 @@ else
 }
 
 @code {
-    public override bool ShowPropertyInTree(PropertyInfo prop) => false;
+    public override bool ShowPropertyInTree(PropertyInfo prop)
+    {
+        // Lmao I hate myself
+        return prop.DeclaringType?.Assembly.FullName?.StartsWith("GBX.NET") == true;
+    }
 }

--- a/Tools/GbxExplorer/Client/Pages/Index.razor
+++ b/Tools/GbxExplorer/Client/Pages/Index.razor
@@ -39,7 +39,7 @@ else
         <SectionLog />
 
         <a class="section section-copyright hoverable" href="https://bigbang1112.cz" target=”_blank”>
-            <span>© 2022 Petr &nbsp;'&nbsp;</span>
+            <span>© 2022-2023 Petr &nbsp;'&nbsp;</span>
             <img style="margin-top: 0.1rem;height: 0.7rem;" src="img/bigbang1112.png">
             <span>&nbsp;'&nbsp; Pivoňka</span>
         </a>


### PR DESCRIPTION
- Added TM2020 action keys, look back, and secondary respawn input support
  - Horn is currently unsupported
- Added `CGameItemModel` `0x022`, fixed `0x01E`
- Added `CGameCtnMediaBlockSpectators`
- Enhanced `CPlugSpriteParam`
- Enhanced CPlugVisualSprite`
- Enhanced `CGameCtnMediaBlockEntity` with a lot of properties
- Enhanced `CGameCtnReplayRecord` with `PlaygroundScript`, `InterfaceScriptInfos`, and some scenery things
- Updated `CPlugSolid2Model.ShadedGeom` with property names
- **Fixed issue with skinnable blocks in `BakedBlocks` (causing many issues with recent maps)**
- Fixed issues with sprite elements in TM2 solids
- Fixed `AppliedWithChunkAttribute` on `CGameCtnChallenge.MapName`
- Fixed 0 header chunk still writing to header data
- Fixed `CGameCtnCollector` `0x008`
- Fixed `CGameObjectVisModel` `0x001`
- `Node.WriteAsync` is now `internal`