### PR TITLE
GBX.NET 1.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Coming soon!
 - 0.0.1 - 0.9.0: System.Drawing.Common
 - 0.13.0+: TmEssentials
 - 0.15.0+: Microsoft.Extensions.Logging.Abstractions
+- 1.2.4+: System.IO.Hashing
 
 ### GBX.NET.Imaging
 - System.Drawing.Common

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -5118,27 +5118,21 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
 
     #endregion
 
-    #region 0x06B skippable chunk [TM2020]
+    #region 0x06B skippable chunk (light settings 2) [TM2020]
 
     /// <summary>
-    /// CGameCtnChallenge 0x06B skippable chunk [TM2020]
+    /// CGameCtnChallenge 0x06B skippable chunk (light settings 2) [TM2020]
     /// </summary>
-    [Chunk(0x0304306B)]
+    [Chunk(0x0304306B, "light settings 2")]
     public class Chunk0304306B : SkippableChunk<CGameCtnChallenge>
     {
-        public int U01;
-        public int U02;
-        public int U03;
-        public int U04;
-        public int U05;
-
         public override void ReadWrite(CGameCtnChallenge n, GameBoxReaderWriter rw)
         {
-            rw.Int32(ref U01);
-            rw.Int32(ref U02);
-            rw.Int32(ref U03);
-            rw.Int32(ref U04);
-            rw.Int32(ref U05);
+            rw.Int32(0);
+            rw.TimeOfDay(ref n.dayTime);
+            rw.Int32(0);
+            rw.Boolean(ref n.dynamicDaylight);
+            rw.TimeInt32Nullable(ref n.dayDuration);
         }
     }
 

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -28,6 +28,7 @@ public partial class CGameCtnGhost
             NotStarted,
             Character,
             Vehicle,
+            VehicleMix
         }
 
         private EVersion version; // 8 in shootmania, 12 in tm2020
@@ -122,6 +123,7 @@ public partial class CGameCtnGhost
             rw.EnumInt32<EVersion>(ref this.version); // 8 in shootmania, 12 in tm2020
             rw.Int32(ref u02);
 
+            // version from the method parameter (the chunk version), NOT this.version
             if (version >= 4)
             {
                 rw.TimeInt32Nullable(ref startOffset);
@@ -428,6 +430,11 @@ public partial class CGameCtnGhost
                             if (started is EStart.NotStarted)
                             {
                                 started = (EStart)(states & 3);
+
+                                if (started is EStart.VehicleMix)
+                                {
+                                    started = EStart.Vehicle;
+                                }
                             }
 
                             if (started is EStart.Character)

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.PlayerInputData.cs
@@ -728,6 +728,12 @@ public partial class CGameCtnGhost
                         if (started is EStart.NotStarted)
                         {
                             started = (EStart)(states & 3);
+
+                            if (started is EStart.VehicleMix)
+                            {
+                                started = EStart.Vehicle;
+                            }
+
                             horn = (states & 64) != 0; // a weird bit that can appear sometimes during the run too
                         }
                         else if (started is EStart.Vehicle)

--- a/Src/GBX.NET/Engines/Game/CGameCtnGhost.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnGhost.cs
@@ -489,7 +489,7 @@ public partial class CGameCtnGhost : CGameGhost
         
         public bool U03;
         public int[]? U04;
-        public int? U05;
+        public int U05;
         public int? U06;
 
         public int Version { get => version; set => version = value; }
@@ -539,7 +539,7 @@ public partial class CGameCtnGhost : CGameGhost
 
                     if (Version >= 5)
                     {
-                        if (Version >= 9)
+                        if (Version >= 9) // Not in code?
                         {
                             rw.Int32(ref U06);
                         }

--- a/Src/GBX.NET/Engines/GameData/CGameCommonItemEntityModel.cs
+++ b/Src/GBX.NET/Engines/GameData/CGameCommonItemEntityModel.cs
@@ -7,6 +7,7 @@ public class CGameCommonItemEntityModel : CMwNod
     private CMwNod? phyModel;
     private CMwNod? visModel;
     private CMwNod? staticObject;
+    private CPlugSurface? triggerShape;
 
     [NodeMember(ExactlyNamed = true)]
     [AppliedWithChunk<Chunk2E027000>]
@@ -19,6 +20,10 @@ public class CGameCommonItemEntityModel : CMwNod
     [NodeMember(ExactlyNamed = true)]
     [AppliedWithChunk<Chunk2E027000>(sinceVersion: 4)]
     public CMwNod? StaticObject { get => staticObject; set => staticObject = value; }
+
+    [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk<Chunk2E027000>(sinceVersion: 4)]
+    public CPlugSurface? TriggerShape { get => triggerShape; set => triggerShape = value; }
 
     internal CGameCommonItemEntityModel()
     {
@@ -35,20 +40,67 @@ public class CGameCommonItemEntityModel : CMwNod
     {
         private int version;
 
+        public string? U01;
+        public string? U02;
+        public Iso4? U03;
+        public CPlugParticleEmitterModel? U04;
+        public CGameActionModel?[]? U05;
+        public Node? U06;
+        public string? U07;
+        public string? U08;
+        public string? U09;
+        public string? U10;
+        public string? U11;
+        public Iso4? U12;
+        public int? U13;
+        public byte? U14;
+
         public int Version { get => version; set => version = value; }
 
         public override void ReadWrite(CGameCommonItemEntityModel n, GameBoxReaderWriter rw)
         {
             rw.Int32(ref version);
 
-            if (version >= 4)
+            if (version == 0)
+            {
+                rw.NodeRef<CMwNod>(ref n.phyModel);
+                rw.NodeRef<CMwNod>(ref n.visModel);
+            }
+            else if (version == 3)
+            {
+                rw.String(ref U01);
+                rw.String(ref U02);
+            }
+            else
             {
                 rw.NodeRef<CMwNod>(ref n.staticObject);
-                return;
             }
 
-            rw.NodeRef<CMwNod>(ref n.phyModel);
-            rw.NodeRef<CMwNod>(ref n.visModel);
+            if (version >= 2)
+            {
+                rw.NodeRef<CPlugSurface>(ref n.triggerShape);
+                rw.Iso4(ref U03);
+                rw.NodeRef<CPlugParticleEmitterModel>(ref U04);
+                rw.ArrayNode<CGameActionModel>(ref U05);
+
+                if (version < 6)
+                {
+                    rw.NodeRef(ref U06);
+                }
+
+                rw.String(ref U07);
+                rw.String(ref U08);
+                rw.String(ref U09);
+                rw.String(ref U10);
+                rw.String(ref U11);
+                rw.Iso4(ref U12);
+                rw.Int32(ref U13); // ExprValidator
+
+                if (version >= 5)
+                {
+                    rw.Byte(ref U14);
+                }
+            }
         }
     }
 

--- a/Src/GBX.NET/Engines/GameData/CGameItemPlacementParam.cs
+++ b/Src/GBX.NET/Engines/GameData/CGameItemPlacementParam.cs
@@ -361,5 +361,18 @@ public class CGameItemPlacementParam : CMwNod
 
     #endregion
 
+    #region 0x005 skippable chunk
+
+    /// <summary>
+    /// CGameItemPlacementParam 0x005 skippable chunk
+    /// </summary>
+    [Chunk(0x2E020005), IgnoreChunk]
+    public class Chunk2E020005 : SkippableChunk<CGameItemPlacementParam>
+    {
+        // NPlugItemPlacement_SClass noderef
+    }
+
+    #endregion
+
     #endregion
 }

--- a/Src/GBX.NET/Engines/Plug/CPlugStaticObjectModel.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugStaticObjectModel.cs
@@ -22,10 +22,8 @@ public class CPlugStaticObjectModel : CMwNod
         U01 = r.ReadInt32();
         Mesh = r.ReadNodeRef<CPlugSolid2Model>();
 
-        if (r.ReadByte() == 0)
-        {
-            Shape = r.ReadNodeRef<CPlugSurface>();
-        }
+        r.ReadByte();
+        Shape = r.ReadNodeRef<CPlugSurface>();
     }
 
     protected override Task ReadChunkDataAsync(GameBoxReader r, CancellationToken cancellationToken)
@@ -40,10 +38,7 @@ public class CPlugStaticObjectModel : CMwNod
         w.Write(Mesh);
 
         w.Write(Shape is null ? (byte)1 : (byte)0);
-        if (Shape is not null)
-        {
-            w.Write(Shape);
-        }
+        w.Write(Shape);
     }
 
     protected override Task WriteChunkDataAsync(GameBoxWriter w, CancellationToken cancellationToken)

--- a/Src/GBX.NET/Engines/Plug/CPlugStaticObjectModel.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugStaticObjectModel.cs
@@ -8,8 +8,9 @@ public class CPlugStaticObjectModel : CMwNod
 
     [NodeMember(ExactlyNamed = true)]
     public CPlugSolid2Model? Mesh { get; set; }
-    
-    public byte U02 { get; set; }
+
+    [NodeMember(ExactlyNamed = true)]
+    public CPlugSurface? Shape { get; set; }
 
     internal CPlugStaticObjectModel()
     {
@@ -20,7 +21,11 @@ public class CPlugStaticObjectModel : CMwNod
     {
         U01 = r.ReadInt32();
         Mesh = r.ReadNodeRef<CPlugSolid2Model>();
-        U02 = r.ReadByte();
+
+        if (r.ReadByte() == 0)
+        {
+            Shape = r.ReadNodeRef<CPlugSurface>();
+        }
     }
 
     protected override Task ReadChunkDataAsync(GameBoxReader r, CancellationToken cancellationToken)
@@ -33,7 +38,12 @@ public class CPlugStaticObjectModel : CMwNod
     {
         w.Write(U01);
         w.Write(Mesh);
-        w.Write(U02);
+
+        w.Write(Shape is null ? (byte)1 : (byte)0);
+        if (Shape is not null)
+        {
+            w.Write(Shape);
+        }
     }
 
     protected override Task WriteChunkDataAsync(GameBoxWriter w, CancellationToken cancellationToken)

--- a/Src/GBX.NET/Engines/Plug/CPlugStaticObjectModel.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugStaticObjectModel.cs
@@ -4,10 +4,14 @@
 [Node(0x09159000)]
 public class CPlugStaticObjectModel : CMwNod
 {
+    [NodeMember]
     public int U01 { get; set; }
 
     [NodeMember(ExactlyNamed = true)]
     public CPlugSolid2Model? Mesh { get; set; }
+
+    [NodeMember]
+    public bool U02 { get; set; }
 
     [NodeMember(ExactlyNamed = true)]
     public CPlugSurface? Shape { get; set; }
@@ -21,9 +25,12 @@ public class CPlugStaticObjectModel : CMwNod
     {
         U01 = r.ReadInt32();
         Mesh = r.ReadNodeRef<CPlugSolid2Model>();
+        U02 = r.ReadBoolean(asByte: true);
 
-        r.ReadByte();
-        Shape = r.ReadNodeRef<CPlugSurface>();
+        if (!U02)
+        {
+            Shape = r.ReadNodeRef<CPlugSurface>();
+        }
     }
 
     protected override Task ReadChunkDataAsync(GameBoxReader r, CancellationToken cancellationToken)
@@ -36,9 +43,12 @@ public class CPlugStaticObjectModel : CMwNod
     {
         w.Write(U01);
         w.Write(Mesh);
+        w.Write(U02, asByte: true);
 
-        w.Write(Shape is null ? (byte)1 : (byte)0);
-        w.Write(Shape);
+        if (!U02)
+        {
+            w.Write(Shape);
+        }
     }
 
     protected override Task WriteChunkDataAsync(GameBoxWriter w, CancellationToken cancellationToken)

--- a/Src/GBX.NET/Engines/Plug/CPlugStaticObjectModel.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugStaticObjectModel.cs
@@ -10,18 +10,6 @@ public class CPlugStaticObjectModel : CMwNod
     public CPlugSolid2Model? Mesh { get; set; }
     
     public byte U02 { get; set; }
-    public int U03 { get; set; }
-    public Iso4 U04 { get; set; }
-    public int U05 { get; set; }
-    public int U06 { get; set; }
-    public int U07 { get; set; }
-    public int U08 { get; set; }
-    public int U09 { get; set; }
-    public int U10 { get; set; }
-    public int U11 { get; set; }
-    public int U12 { get; set; }
-    public Iso4 U13 { get; set; }
-    public int U14 { get; set; }
 
     internal CPlugStaticObjectModel()
     {
@@ -33,18 +21,6 @@ public class CPlugStaticObjectModel : CMwNod
         U01 = r.ReadInt32();
         Mesh = r.ReadNodeRef<CPlugSolid2Model>();
         U02 = r.ReadByte();
-        U03 = r.ReadInt32();
-        U04 = r.ReadIso4();
-        U05 = r.ReadInt32();
-        U06 = r.ReadInt32();
-        U07 = r.ReadInt32();
-        U08 = r.ReadInt32();
-        U09 = r.ReadInt32();
-        U10 = r.ReadInt32();
-        U11 = r.ReadInt32();
-        U12 = r.ReadInt32();
-        U13 = r.ReadIso4();
-        U14 = r.ReadInt32();
     }
 
     protected override Task ReadChunkDataAsync(GameBoxReader r, CancellationToken cancellationToken)
@@ -58,18 +34,6 @@ public class CPlugStaticObjectModel : CMwNod
         w.Write(U01);
         w.Write(Mesh);
         w.Write(U02);
-        w.Write(U03);
-        w.Write(U04);
-        w.Write(U05);
-        w.Write(U06);
-        w.Write(U07);
-        w.Write(U08);
-        w.Write(U09);
-        w.Write(U10);
-        w.Write(U11);
-        w.Write(U12);
-        w.Write(U13);
-        w.Write(U14);
     }
 
     protected override Task WriteChunkDataAsync(GameBoxWriter w, CancellationToken cancellationToken)

--- a/Src/GBX.NET/Engines/Plug/CPlugSurface.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugSurface.cs
@@ -153,7 +153,7 @@ public partial class CPlugSurface : CPlug
         public int U01;
         public byte[]? U02;
 
-        public int U06;
+        public byte U03;
 
         public int Version { get => version; set => version = value; }
 
@@ -169,8 +169,13 @@ public partial class CPlugSurface : CPlug
             ArchiveSurf(ref n.surf, rw, n.surfVersion, version);
 
             rw.ArrayArchiveWithGbx<SurfMaterial>(ref n.materials); // ArchiveMaterials
-            
+
             rw.Bytes(ref U02);
+
+            if (version >= 4)
+            {
+                rw.Byte(ref U03);
+            }
 
             if (version >= 1)
             {

--- a/Src/GBX.NET/Engines/Plug/CPlugTree.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugTree.cs
@@ -204,6 +204,24 @@ public class CPlugTree : CPlug
 
     #endregion
 
+    #region 0x017 chunk
+
+    /// <summary>
+    /// CPlugTree 0x017 chunk
+    /// </summary>
+    [Chunk(0x0904F017)]
+    public class Chunk0904F017 : Chunk<CPlugTree>
+    {
+        public CPlugVisual? U01;
+
+        public override void ReadWrite(CPlugTree n, GameBoxReaderWriter rw)
+        {
+            rw.NodeRef<CPlugVisual>(ref U01);
+        }
+    }
+
+    #endregion
+
     #region 0x018 chunk (translation)
 
     /// <summary>

--- a/Src/GBX.NET/GBX.NET.csproj
+++ b/Src/GBX.NET/GBX.NET.csproj
@@ -12,7 +12,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IsTrimmable>true</IsTrimmable>
 
-		<Version>1.2.3</Version>
+		<Version>1.2.4</Version>
 		<PackageReleaseNotes></PackageReleaseNotes>
 
 		<TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>

--- a/Src/GBX.NET/GBX.NET.csproj
+++ b/Src/GBX.NET/GBX.NET.csproj
@@ -77,6 +77,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+		<PackageReference Include="System.IO.Hashing" Version="8.0.0" />
 		<PackageReference Include="TmEssentials" Version="2.3.2" />
 		<ProjectReference Include="..\..\Generators\GBX.NET.Generators\GBX.NET.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 	</ItemGroup>

--- a/Tests/GBX.NET.Tests/Integration/Engines/Game/CGameCtnChallengeTests.cs
+++ b/Tests/GBX.NET.Tests/Integration/Engines/Game/CGameCtnChallengeTests.cs
@@ -38,6 +38,12 @@ public partial class CGameCtnChallengeTests
         public partial void ReadAndWrite_TMUF_DataShouldEqual();
     }
 
+    [IgnoreReadWriteEqualityTest]
+    public partial class Chunk03043029Tests
+    {
+
+    }
+
     public partial class Chunk0304303ETests
     {
         [IgnoreReadWriteEqualityTest]


### PR DESCRIPTION
- **Fixed TM2020 input reading bug when car transformation is used** https://github.com/BigBang1112/gbx-net/pull/84/commits/6e92668dd21bdfb9a4715ad460cf77ccae011d32 https://github.com/BigBang1112/gbx-net/pull/84/commits/5eb5ccdcfd110cda3d6e3c55b4bdad1f2db1a813
- Added CRC32 calculation on map save. **No more random password prompts!**
- Added `CPlugTree` `0x017` https://github.com/BigBang1112/gbx-net/pull/84/commits/480163f0e9ef7335efc30b739cb18601d6704f5d
- Fixed `CGameCommonItemEntityModel` and `CPlugStaticObjectModel` (thx schadocalex)
- Fixed `CPlugSurface` `0x003` v4
- Removed warning from `CGameItemPlacementParam` `0x005` https://github.com/BigBang1112/gbx-net/pull/84/commits/50e8787b509e7bae61e7948d8bea5ca139156b19
- Connected `CGameCtnChallenge` `0x06B` with dynamic daytime https://github.com/BigBang1112/gbx-net/pull/84/commits/7990cee9a9ebe9d0ab191a216e2b2ebfab7f40ed