### PR TITLE
GBX.NET 1.2.5

### DIFF
--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -1280,16 +1280,19 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     /// </summary>
     [NodeMember]
     [AppliedWithChunk<Chunk03043056>]
+    [AppliedWithChunk<Chunk0304306B>]
     public TimeSpan? DayTime
     {
         get
         {
             DiscoverChunk<Chunk03043056>();
+            DiscoverChunk<Chunk0304306B>();
             return dayTime;
         }
         set
         {
             DiscoverChunk<Chunk03043056>();
+            DiscoverChunk<Chunk0304306B>();
             dayTime = value;
         }
     }
@@ -1299,16 +1302,19 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     /// </summary>
     [NodeMember]
     [AppliedWithChunk<Chunk03043056>]
+    [AppliedWithChunk<Chunk0304306B>]
     public bool DynamicDaylight
     {
         get
         {
             DiscoverChunk<Chunk03043056>();
+            DiscoverChunk<Chunk0304306B>();
             return dynamicDaylight;
         }
         set
         {
             DiscoverChunk<Chunk03043056>();
+            DiscoverChunk<Chunk0304306B>();
             dynamicDaylight = value;
         }
     }
@@ -1318,16 +1324,19 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     /// </summary>
     [NodeMember]
     [AppliedWithChunk<Chunk03043056>]
+    [AppliedWithChunk<Chunk0304306B>]
     public TimeInt32? DayDuration
     {
         get
         {
             DiscoverChunk<Chunk03043056>();
+            DiscoverChunk<Chunk0304306B>();
             return dayDuration;
         }
         set
         {
             DiscoverChunk<Chunk03043056>();
+            DiscoverChunk<Chunk0304306B>();
             dayDuration = value;
         }
     }

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -4033,9 +4033,9 @@ public partial class CGameCtnChallenge : CMwNod, CGameCtnChallenge.IHeader
     #region 0x043 skippable chunk (genealogies)
 
     /// <summary>
-    /// CGameCtnChallenge 0x043 skippable chunk (generalogies)
+    /// CGameCtnChallenge 0x043 skippable chunk (genealogies)
     /// </summary>
-    [Chunk(0x03043043, "generalogies")]
+    [Chunk(0x03043043, "genealogies")]
     public class Chunk03043043 : SkippableChunk<CGameCtnChallenge>
     {
         public int U01;

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockCameraOrbital.Key.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockCameraOrbital.Key.cs
@@ -1,0 +1,59 @@
+﻿namespace GBX.NET.Engines.Game;
+
+public partial class CGameCtnMediaBlockCameraOrbital
+{
+    public new class Key : CGameCtnMediaBlock.Key
+    {
+        private float radius;
+        private float longitude;
+        private float latitude;
+        private Vec3 targetPosition;
+        private float fov;
+        private float u01;
+        private float u02;
+        private int u03;
+        private int u04;
+        private int u05;
+        private int u06;
+        private int u07;
+
+        public float Radius { get => radius; set => radius = value; }
+        public float Longitude { get => longitude; set => longitude = value; }
+        public float Latitude { get => latitude; set => latitude = value; }
+        public Vec3 TargetPosition { get => targetPosition; set => targetPosition = value; }
+        public float Fov { get => fov; set => fov = value; }
+        public float U01 { get => u01; set => u01 = value; }
+        public float U02 { get => u02; set => u02 = value; }
+        public int U03 { get => u03; set => u03 = value; }
+        public int U04 { get => u04; set => u04 = value; }
+        public int U05 { get => u05; set => u05 = value; }
+        public int U06 { get => u06; set => u06 = value; }
+        public int U07 { get => u07; set => u07 = value; }
+
+        public override void ReadWrite(GameBoxReaderWriter rw, int version = 0)
+        {
+            base.ReadWrite(rw, version);
+
+            // GmCamOrbitVal::Archive
+            rw.Byte(0);
+            rw.Single(ref radius);
+            rw.Single(ref longitude);
+            rw.Single(ref latitude);
+            rw.Vec3(ref targetPosition);
+            rw.Single(ref fov);
+            rw.Single(ref u01);
+            rw.Single(ref u02);
+            //
+
+            rw.Int32(ref u03);
+
+            if (version >= 1)
+            {
+                rw.Int32(ref u04);
+                rw.Int32(ref u05);
+                rw.Int32(ref u06);
+                rw.Int32(ref u07);
+            }
+        }
+    }
+}

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockCameraOrbital.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockCameraOrbital.cs
@@ -2,8 +2,20 @@
 
 /// <remarks>ID: 0x030A0000</remarks>
 [Node(0x030A0000)]
-public class CGameCtnMediaBlockCameraOrbital : CGameCtnMediaBlock
+public partial class CGameCtnMediaBlockCameraOrbital : CGameCtnMediaBlock, CGameCtnMediaBlock.IHasKeys
 {
+    private IList<Key> keys = Array.Empty<Key>();
+
+    IEnumerable<CGameCtnMediaBlock.Key> IHasKeys.Keys
+    {
+        get => keys.Cast<CGameCtnMediaBlock.Key>();
+        set => keys = value.Cast<Key>().ToList();
+    }
+
+    [NodeMember]
+    [AppliedWithChunk<Chunk030A0001>]
+    public IList<Key> Keys { get => keys; set => keys = value; }
+
     internal CGameCtnMediaBlockCameraOrbital()
     {
 
@@ -13,9 +25,14 @@ public class CGameCtnMediaBlockCameraOrbital : CGameCtnMediaBlock
     /// CGameCtnMediaBlockCameraOrbital 0x001 chunk
     /// </summary>
     [Chunk(0x030A0001)]
-    [AutoReadWriteChunk]
-    public class Chunk030A0001 : Chunk<CGameCtnMediaBlockCameraOrbital>
+    public class Chunk030A0001 : Chunk<CGameCtnMediaBlockCameraOrbital>, IVersionable
     {
-        
+        public int Version { get; set; }
+
+        public override void ReadWrite(CGameCtnMediaBlockCameraOrbital n, GameBoxReaderWriter rw)
+        {
+            rw.VersionInt32(this);
+            rw.ListKey(ref n.keys!, Version);
+        }
     }
 }

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockEntity.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockEntity.cs
@@ -138,7 +138,7 @@ public partial class CGameCtnMediaBlockEntity : CGameCtnMediaBlock, CGameCtnMedi
         public string? U11;
         public int? U12;
         public int? U13;
-        public int? U14;
+        public string? U14;
         public int? U15;
         public int? U16;
 
@@ -200,7 +200,7 @@ public partial class CGameCtnMediaBlockEntity : CGameCtnMediaBlock, CGameCtnMedi
                     {
                         if (version >= 11)
                         {
-                            rw.Int32(ref U14);
+                            rw.String(ref U14);
                         }
 
                         rw.ListKey<Key>(ref n.keys, version);

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockEntity.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaBlockEntity.cs
@@ -106,6 +106,7 @@ public partial class CGameCtnMediaBlockEntity : CGameCtnMediaBlock, CGameCtnMedi
     public Badge? Badge { get => badge; set => badge = value; }
 
     [NodeMember]
+    [AppliedWithChunk<Chunk0329F000>(sinceVersion: 11)]
     [AppliedWithChunk<Chunk0329F002>]
     public string? SkinOptions { get => skinOptions; set => skinOptions = value; }
 
@@ -138,7 +139,6 @@ public partial class CGameCtnMediaBlockEntity : CGameCtnMediaBlock, CGameCtnMedi
         public string? U11;
         public int? U12;
         public int? U13;
-        public string? U14;
         public int? U15;
         public int? U16;
 
@@ -200,7 +200,7 @@ public partial class CGameCtnMediaBlockEntity : CGameCtnMediaBlock, CGameCtnMedi
                     {
                         if (version >= 11)
                         {
-                            rw.String(ref U14);
+                            rw.String(ref n.skinOptions);
                         }
 
                         rw.ListKey<Key>(ref n.keys, version);

--- a/Src/GBX.NET/Engines/GameData/CGameItemModel.cs
+++ b/Src/GBX.NET/Engines/GameData/CGameItemModel.cs
@@ -328,13 +328,9 @@ public partial class CGameItemModel : CGameCtnCollector, CGameItemModel.IHeader 
     [Chunk(0x2E002009, "cameras")]
     public class Chunk2E002009 : Chunk<CGameItemModel>
     {
-        private int version;
-
-        public int Version { get => version; set => version = value; }
-
         public override void ReadWrite(CGameItemModel n, GameBoxReaderWriter rw)
         {
-            rw.Int32(ref version);
+            rw.Int32(10);
             rw.ArrayNode(ref n.cameras);
         }
     }

--- a/Src/GBX.NET/Engines/Plug/CPlugFileGen.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugFileGen.cs
@@ -4,10 +4,18 @@
 [Node(0x0902F000)]
 public class CPlugFileGen : CPlugFileImg
 {
-    public int U01 { get; set; }
-    public int? U02 { get; set; }
-    public int[]? U03 { get; set; }
-    public Vec4[]? U04 { get; set; }
+    [NodeMember(ExactlyNamed = true)]
+    public int Version { get; set; }
+
+    [NodeMember(ExactlyNamed = true)]
+    public int? GenKind { get; set; }
+
+    [NodeMember(ExactlyNamed = true)]
+    public int[]? GenNatural { get; set; }
+
+    [NodeMember]
+    public Vec4[]? GenColor { get; set; } // GxColor
+
     public float[]? U05 { get; set; }
 
     internal CPlugFileGen()
@@ -17,21 +25,21 @@ public class CPlugFileGen : CPlugFileImg
 
     protected override void ReadChunkData(GameBoxReader r, IProgress<GameBoxReadProgress>? progress, bool ignoreZeroIdChunk)
     {
-        U01 = r.ReadInt32();
+        Version = r.ReadInt32();
 
-        if (U01 < 0)
+        if (Version < 0)
         {
-            U01 &= 0x7fffffff;
+            Version &= 0x7fffffff;
 
-            U02 = r.ReadInt32();
-            U03 = r.ReadArray<int>();
-            U04 = r.ReadArray<Vec4>();
+            GenKind = r.ReadInt32();
+            GenNatural = r.ReadArray<int>();
+            GenColor = r.ReadArray<Vec4>();
             U05 = r.ReadArray<float>();
         }
         else
         {
-            U03 = r.ReadArray<int>();
-            U04 = r.ReadArray<Vec4>();
+            GenNatural = r.ReadArray<int>();
+            GenColor = r.ReadArray<Vec4>();
         }
     }
 

--- a/Src/GBX.NET/Engines/Plug/CPlugSolid.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugSolid.cs
@@ -240,16 +240,28 @@ public class CPlugSolid : CPlug
 
         public override void ReadWrite(CPlugSolid n, GameBoxReaderWriter rw)
         {
-            rw.Boolean(ref U01);
-            rw.Boolean(ref U02);
-            rw.NodeRef<CPlug>(ref n.tree, ref n.treeFile);
+            rw.Boolean(ref U01); // part of SetUseModel, possibly the 'Use' parameter
+            rw.Boolean(ref U02); // m_Model != null
+
+            if (U02) // True when referenced through CHmsItem?
+            {
+                // m_Model noderef
+            }
+
+            rw.NodeRef<CPlug>(ref n.tree, ref n.treeFile); // only if U02 is false?
         }
 
         public override async Task ReadWriteAsync(CPlugSolid n, GameBoxReaderWriter rw, CancellationToken cancellationToken = default)
         {
-            rw.Boolean(ref U01);
-            rw.Boolean(ref U02);
-            n.tree = await rw.NodeRefAsync<CPlug>(n.tree, cancellationToken);
+            rw.Boolean(ref U01); // part of SetUseModel, possibly the 'Use' parameter
+            rw.Boolean(ref U02); // m_Model != null
+
+            if (U02) // True when referenced through CHmsItem?
+            {
+                // m_Model noderef
+            }
+
+            n.tree = await rw.NodeRefAsync<CPlug>(n.tree, cancellationToken); // only if U02 is false?
         }
     }
 
@@ -318,28 +330,30 @@ public class CPlugSolid : CPlug
 
         public override void ReadWrite(CPlugSolid n, GameBoxReaderWriter rw)
         {
-            rw.Boolean(ref U01);
-            rw.Boolean(ref U02);
+            rw.Boolean(ref U01); // part of SetUseModel, possibly the 'Use' parameter
+            rw.Boolean(ref U02); // m_Model != null
 
             if (U02) // True when referenced through CHmsItem?
             {
                 rw.Boolean(ref U03);
+                // m_Model noderef
             }
 
-            rw.NodeRef<CPlug>(ref n.tree, ref n.treeFile); // only of U02 is false?
+            rw.NodeRef<CPlug>(ref n.tree, ref n.treeFile); // only if U02 is false?
         }
 
         public override async Task ReadWriteAsync(CPlugSolid n, GameBoxReaderWriter rw, CancellationToken cancellationToken = default)
         {
-            rw.Boolean(ref U01);
-            rw.Boolean(ref U02);
+            rw.Boolean(ref U01); // part of SetUseModel, possibly the 'Use' parameter
+            rw.Boolean(ref U02); // m_Model != null
 
             if (U02) // True when referenced through CHmsItem?
             {
                 rw.Boolean(ref U03);
+                // m_Model noderef
             }
-            
-            n.tree = await rw.NodeRefAsync<CPlug>(n.tree, cancellationToken); // only of U02 is false?
+
+            n.tree = await rw.NodeRefAsync<CPlug>(n.tree, cancellationToken); // only if U02 is false?
         }
     }
 

--- a/Src/GBX.NET/Engines/Plug/CPlugSolid.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugSolid.cs
@@ -19,6 +19,7 @@ public class CPlugSolid : CPlug
     private DateTime? fileWriteTime;
 
     [NodeMember(ExactlyNamed = true)]
+    [AppliedWithChunk<Chunk09005000>]
     public int TypeAndIndex { get => typeAndIndex; set => typeAndIndex = value; }
     
     [NodeMember(ExactlyNamed = true)]

--- a/Src/GBX.NET/GBX.NET.csproj
+++ b/Src/GBX.NET/GBX.NET.csproj
@@ -12,7 +12,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IsTrimmable>true</IsTrimmable>
 
-		<Version>1.2.4</Version>
+		<Version>1.2.5</Version>
 		<PackageReleaseNotes></PackageReleaseNotes>
 
 		<TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>

--- a/Tools/GbxExplorer/Client/Sections/SectionPreview.razor
+++ b/Tools/GbxExplorer/Client/Sections/SectionPreview.razor
@@ -34,13 +34,14 @@
                         <div style="font-family:Source Code Pro">@header.CompressionOfRefTable</div>
                         <div>Body compression</div>
                         <div style="font-family:Source Code Pro">@header.CompressionOfBody</div>
-                        <div>
-                            <span class="tooltip-small-width" data-title="Is intended to be modified and not overwriten (just a theory).">
-                                Is editable?
-                            </span>
-                        </div>
+
                         @if (header.UnknownByte.HasValue)
                         {
+                            <div>
+                                <span class="tooltip-small-width" data-title="Is intended to be modified and not overwriten (just a theory).">
+                                    Is editable?
+                                </span>
+                            </div>
                             <div style="font-family:Source Code Pro">
                                 @switch (header.UnknownByte)
                                 {


### PR DESCRIPTION
- Implemented and fixed `CGameCtnMediaBlockCameraOrbital` [648c0ba](https://github.com/BigBang1112/gbx-net/pull/85/commits/648c0ba1468776c1989f5e12cee8826043dc3021)
- Implemented `CPlugFileGen` [22db2f4](https://github.com/BigBang1112/gbx-net/pull/85/commits/22db2f44654865b2c32b8ed7abaffce19e3c5ba7)
- Improved handling of CRC32 calculation [0179bdf](https://github.com/BigBang1112/gbx-net/pull/85/commits/0179bdf81d90c7be539c2fae219573eb868fc0a5)
- Fixed `CGameCtnMediaBlockEntity` `0x000` `U14` to be `SkinOptions` [8fc3b5b](https://github.com/BigBang1112/gbx-net/pull/85/commits/8fc3b5b75fa9d655d9375de7e775450f66cfb11c)
- Removed `Version` from `Chunk2E002009` [52eb086](https://github.com/BigBang1112/gbx-net/pull/85/commits/52eb08620d9ced58f94b0cfbdb12cb060ad34241)
- Updated TmEssentials to 2.4.0 [ee2ddd9](https://github.com/BigBang1112/gbx-net/pull/85/commits/ee2ddd9bf0bb6f5c55a8cbf5de95ca700a948660)