### PR TITLE
GBX.NET 2.0.9

### DIFF
--- a/.github/workflows/deploy-explorer-docker.yml
+++ b/.github/workflows/deploy-explorer-docker.yml
@@ -6,7 +6,6 @@ on:
 
 env:
   IMAGE_NAME: gbx-explorer
-  BUILD_CONTEXT: Tools/GbxExplorerOld/Server
 
 jobs:
   build-and-push:
@@ -49,7 +48,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
-          context: ${{ env.BUILD_CONTEXT }}
+          file: Tools/GbxExplorerOld/Server/Dockerfile
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
           push: true

--- a/.github/workflows/deploy-explorer-docker.yml
+++ b/.github/workflows/deploy-explorer-docker.yml
@@ -1,36 +1,30 @@
-name: Deploy Explorer to Docker Hub
+name: Docker Image Publish - Explorer
 
 on:
   release:
     types: [ published ]
 
 env:
-  REGISTRY_IMAGE: ${{ vars.DOCKERHUB_USERNAME }}/gbx-explorer
+  IMAGE_NAME: gbx-explorer
+  BUILD_CONTEXT: Tools/GbxExplorerOld/Server
 
 jobs:
-  build:
+  build-and-push:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-    
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-      
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY_IMAGE }}
-      
+          images: |
+            ${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+          
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       
@@ -43,68 +37,23 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
-      - name: Build and push by digest
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Build and push
         id: build
         uses: docker/build-push-action@v6
         with:
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
+          context: ${{ env.BUILD_CONTEXT }}
           labels: ${{ steps.meta.outputs.labels }}
-          file: Tools/GbxExplorerOld/Server/Dockerfile
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          tags: ${{ steps.meta.outputs.tags }}
+          push: true
           build-args: |
             BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
           secrets: |
             github_token=${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-      
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          tags: |
-            type=semver,pattern={{version}}
-      
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-      
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/deploy-explorer-docker.yml
+++ b/.github/workflows/deploy-explorer-docker.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [ published ]
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   IMAGE_NAME: gbx-explorer
 

--- a/.github/workflows/deploy-explorer-docker.yml
+++ b/.github/workflows/deploy-explorer-docker.yml
@@ -3,39 +3,108 @@ name: Deploy Explorer to Docker Hub
 on:
   release:
     types: [ published ]
-    
+
 env:
-  BUILD_DIR: Tools/GbxExplorerOld/Server
-  IMAGE_NAME: gbx-explorer
+  REGISTRY_IMAGE: ${{ vars.DOCKERHUB_USERNAME }}/gbx-explorer
 
 jobs:
-
-  build-and-push:
-
+  build:
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
-    - uses: actions/checkout@v4
-
-    - name: Set lowercase repository_owner and tag_name without v
-      run: |
-        echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
-        echo "VERSION=${TAG#v}" >>${GITHUB_ENV}
-      env:
-        OWNER: '${{ github.repository_owner }}'
-        TAG: '${{ github.event.release.tag_name }}'
+      - name: Checkout
+        uses: actions/checkout@v4
+    
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       
-    - name: Build Docker Image
-      run: docker build . -f $BUILD_DIR/Dockerfile -t ghcr.io/$OWNER_LC/$IMAGE_NAME -t ghcr.io/$OWNER_LC/$IMAGE_NAME:$VERSION -t ${{ secrets.DOCKER_USERNAME }}/$IMAGE_NAME -t ${{ secrets.DOCKER_USERNAME }}/$IMAGE_NAME:$VERSION
-    
-    - name: Push the Docker image to ghcr.io
-      run: |
-        echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u USERNAME --password-stdin
-        docker push ghcr.io/$OWNER_LC/$IMAGE_NAME:$VERSION
-        docker push ghcr.io/$OWNER_LC/$IMAGE_NAME
-    
-    - name: Push the Docker image to hub.docker.com
-      run: |
-        echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-        docker push ${{ secrets.DOCKER_USERNAME }}/$IMAGE_NAME:$VERSION
-        docker push ${{ secrets.DOCKER_USERNAME }}/$IMAGE_NAME
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: Tools/GbxExplorerOld/Server/Dockerfile
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+      
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/Src/GBX.NET.Tool.CLI/ArgsResolver.cs
+++ b/Src/GBX.NET.Tool.CLI/ArgsResolver.cs
@@ -24,7 +24,7 @@ internal sealed class ArgsResolver
         }
 
         var configOverwrites = new Dictionary<string, string>();
-        var inputs = new List<Input>();
+        var inputs = new List<InputArgument>();
 
         var argsEnumerator = args.AsEnumerable().GetEnumerator();
 
@@ -114,13 +114,13 @@ internal sealed class ArgsResolver
             // - check for configured user data path
             if (Directory.Exists(arg))
             {
-                inputs.Add(new DirectoryInput(arg));
+                inputs.Add(new DirectoryInputArgument(arg));
                 continue;
             }
 
             if (File.Exists(arg))
             {
-                inputs.Add(new FileInput(arg));
+                inputs.Add(new FileInputArgument(arg));
                 continue;
             }
 
@@ -128,7 +128,7 @@ internal sealed class ArgsResolver
             {
                 if (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
                 {
-                    inputs.Add(new UriInput(client, uri));
+                    inputs.Add(new UriInputArgument(client, uri));
                 }
 
                 continue;
@@ -137,7 +137,7 @@ internal sealed class ArgsResolver
 
         return new ToolSettings
         {
-            Inputs = inputs,
+            InputArguments = inputs,
             ConfigOverwrites = configOverwrites,
             ConsoleSettings = consoleOptions
         };

--- a/Src/GBX.NET.Tool.CLI/ArgsResolver.cs
+++ b/Src/GBX.NET.Tool.CLI/ArgsResolver.cs
@@ -18,7 +18,7 @@ internal sealed class ArgsResolver
 
     public ToolSettings Resolve(ConsoleSettings consoleOptions)
     {
-        if (!HasArgs)
+        if (!HasArgs && !Console.IsInputRedirected)
         {
             return new ToolSettings { ConsoleSettings = consoleOptions };
         }
@@ -31,14 +31,12 @@ internal sealed class ArgsResolver
         // - check for folders
         // - check for stdin (maybe?)
         // - check for configured user data path
-        var stream = new BufferedStream(Console.OpenStandardInput());
 
-        if (stream.CanRead)
+        if (Console.IsInputRedirected)
         {
-            inputs.Add(new StandardInputArgument(stream));
+            inputs.Add(new StandardInputArgument(Console.OpenStandardInput()));
+            inputs.Add(new StandardTextInputArgument(Console.In));
         }
-
-        inputs.Add(new StandardTextInputArgument(Console.In));
 
         var argsEnumerator = args.AsEnumerable().GetEnumerator();
 

--- a/Src/GBX.NET.Tool.CLI/ArgsResolver.cs
+++ b/Src/GBX.NET.Tool.CLI/ArgsResolver.cs
@@ -1,5 +1,5 @@
 ﻿using GBX.NET.Tool.CLI.Exceptions;
-using GBX.NET.Tool.CLI.Inputs;
+using GBX.NET.Tool.CLI.InputArguments;
 
 namespace GBX.NET.Tool.CLI;
 

--- a/Src/GBX.NET.Tool.CLI/InputArguments/DirectoryInputArgument.cs
+++ b/Src/GBX.NET.Tool.CLI/InputArguments/DirectoryInputArgument.cs
@@ -1,7 +1,7 @@
 ﻿
 using GBX.NET.Exceptions;
 
-namespace GBX.NET.Tool.CLI.Inputs;
+namespace GBX.NET.Tool.CLI.InputArguments;
 
 public sealed record DirectoryInputArgument(string DirectoryPath) : InputArgument
 {

--- a/Src/GBX.NET.Tool.CLI/InputArguments/FileInputArgument.cs
+++ b/Src/GBX.NET.Tool.CLI/InputArguments/FileInputArgument.cs
@@ -1,7 +1,7 @@
 ﻿
 using GBX.NET.Exceptions;
 
-namespace GBX.NET.Tool.CLI.Inputs;
+namespace GBX.NET.Tool.CLI.InputArguments;
 
 public sealed record FileInputArgument(string FilePath) : InputArgument
 {

--- a/Src/GBX.NET.Tool.CLI/InputArguments/InputArgument.cs
+++ b/Src/GBX.NET.Tool.CLI/InputArguments/InputArgument.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace GBX.NET.Tool.CLI.Inputs;
+namespace GBX.NET.Tool.CLI.InputArguments;
 
 public abstract record InputArgument
 {

--- a/Src/GBX.NET.Tool.CLI/InputArguments/StandardInputArgument.cs
+++ b/Src/GBX.NET.Tool.CLI/InputArguments/StandardInputArgument.cs
@@ -1,27 +1,9 @@
-﻿using GBX.NET.Exceptions;
-
-namespace GBX.NET.Tool.CLI.InputArguments;
+﻿namespace GBX.NET.Tool.CLI.InputArguments;
 
 public sealed record StandardInputArgument(Stream Stream) : InputArgument
 {
-    public override async Task<object?> ResolveAsync(CancellationToken cancellationToken)
+    public override Task<object?> ResolveAsync(CancellationToken cancellationToken)
     {
-        var position = Stream.Position;
-
-        try
-        {
-            if (Gbx.IsCompressed(Stream))
-            {
-                Stream.Position = position;
-                return await Gbx.ParseAsync(Stream, cancellationToken: cancellationToken);
-            }
-        }
-        catch (NotAGbxException)
-        {
-
-        }
-
-        Stream.Position = position;
         return Task.FromResult((object?)Stream);
     }
 }

--- a/Src/GBX.NET.Tool.CLI/InputArguments/StandardInputArgument.cs
+++ b/Src/GBX.NET.Tool.CLI/InputArguments/StandardInputArgument.cs
@@ -1,0 +1,27 @@
+﻿using GBX.NET.Exceptions;
+
+namespace GBX.NET.Tool.CLI.InputArguments;
+
+public sealed record StandardInputArgument(Stream Stream) : InputArgument
+{
+    public override async Task<object?> ResolveAsync(CancellationToken cancellationToken)
+    {
+        var position = Stream.Position;
+
+        try
+        {
+            if (Gbx.IsCompressed(Stream))
+            {
+                Stream.Position = position;
+                return await Gbx.ParseAsync(Stream, cancellationToken: cancellationToken);
+            }
+        }
+        catch (NotAGbxException)
+        {
+
+        }
+
+        Stream.Position = position;
+        return Task.FromResult((object?)Stream);
+    }
+}

--- a/Src/GBX.NET.Tool.CLI/InputArguments/StandardTextInputArgument.cs
+++ b/Src/GBX.NET.Tool.CLI/InputArguments/StandardTextInputArgument.cs
@@ -1,5 +1,4 @@
-﻿
-namespace GBX.NET.Tool.CLI.InputArguments;
+﻿namespace GBX.NET.Tool.CLI.InputArguments;
 
 public sealed record StandardTextInputArgument(TextReader Reader) : InputArgument
 {

--- a/Src/GBX.NET.Tool.CLI/InputArguments/StandardTextInputArgument.cs
+++ b/Src/GBX.NET.Tool.CLI/InputArguments/StandardTextInputArgument.cs
@@ -1,0 +1,10 @@
+﻿
+namespace GBX.NET.Tool.CLI.InputArguments;
+
+public sealed record StandardTextInputArgument(TextReader Reader) : InputArgument
+{
+    public override Task<object?> ResolveAsync(CancellationToken cancellationToken)
+    {
+        return Task.FromResult((object?)Reader);
+    }
+}

--- a/Src/GBX.NET.Tool.CLI/InputArguments/UriInputArgument.cs
+++ b/Src/GBX.NET.Tool.CLI/InputArguments/UriInputArgument.cs
@@ -1,7 +1,7 @@
 ﻿
 using GBX.NET.Exceptions;
 
-namespace GBX.NET.Tool.CLI.Inputs;
+namespace GBX.NET.Tool.CLI.InputArguments;
 
 public sealed record UriInputArgument(HttpClient Http, Uri Uri) : InputArgument
 {

--- a/Src/GBX.NET.Tool.CLI/Inputs/DirectoryInputArgument.cs
+++ b/Src/GBX.NET.Tool.CLI/Inputs/DirectoryInputArgument.cs
@@ -3,7 +3,7 @@ using GBX.NET.Exceptions;
 
 namespace GBX.NET.Tool.CLI.Inputs;
 
-internal sealed record DirectoryInput(string DirectoryPath) : Input
+public sealed record DirectoryInputArgument(string DirectoryPath) : InputArgument
 {
     public override async Task<object?> ResolveAsync(CancellationToken cancellationToken)
     {

--- a/Src/GBX.NET.Tool.CLI/Inputs/FileInputArgument.cs
+++ b/Src/GBX.NET.Tool.CLI/Inputs/FileInputArgument.cs
@@ -3,7 +3,7 @@ using GBX.NET.Exceptions;
 
 namespace GBX.NET.Tool.CLI.Inputs;
 
-internal sealed record FileInput(string FilePath) : Input
+public sealed record FileInputArgument(string FilePath) : InputArgument
 {
     public override async Task<object?> ResolveAsync(CancellationToken cancellationToken)
     {

--- a/Src/GBX.NET.Tool.CLI/Inputs/InputArgument.cs
+++ b/Src/GBX.NET.Tool.CLI/Inputs/InputArgument.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace GBX.NET.Tool.CLI.Inputs;
 
-internal abstract record Input
+public abstract record InputArgument
 {
     public abstract Task<object?> ResolveAsync(CancellationToken cancellationToken);
 }

--- a/Src/GBX.NET.Tool.CLI/Inputs/UriInputArgument.cs
+++ b/Src/GBX.NET.Tool.CLI/Inputs/UriInputArgument.cs
@@ -3,7 +3,7 @@ using GBX.NET.Exceptions;
 
 namespace GBX.NET.Tool.CLI.Inputs;
 
-internal sealed record UriInput(HttpClient Http, Uri Uri) : Input
+public sealed record UriInputArgument(HttpClient Http, Uri Uri) : InputArgument
 {
     public override async Task<object?> ResolveAsync(CancellationToken cancellationToken)
     {

--- a/Src/GBX.NET.Tool.CLI/OutputDistributor.cs
+++ b/Src/GBX.NET.Tool.CLI/OutputDistributor.cs
@@ -3,14 +3,14 @@ using System.Diagnostics;
 
 namespace GBX.NET.Tool.CLI;
 
-internal sealed class OutputDistributor
+public sealed class OutputDistributor
 {
     private readonly ToolSettings toolSettings;
     private readonly ILogger logger;
 
     private readonly string outputDir;
 
-    public OutputDistributor(string runningDir, ToolSettings toolSettings, ILogger logger)
+    public OutputDistributor(ToolSettings toolSettings, string runningDir, ILogger logger)
     {
         this.toolSettings = toolSettings;
         this.logger = logger;

--- a/Src/GBX.NET.Tool.CLI/SettingsManager.cs
+++ b/Src/GBX.NET.Tool.CLI/SettingsManager.cs
@@ -8,7 +8,7 @@ using System.Text.Json.Serialization.Metadata;
 
 namespace GBX.NET.Tool.CLI;
 
-internal sealed class SettingsManager
+public sealed class SettingsManager
 {
     internal const string DynamicCodeMessage = "If JsonContext is not set, or YAML is used and YmlContext is not set, this can cause serialization problems when AOT-compiled.";
     internal const string UnreferencedCodeMessage = "If JsonContext is not set, or YAML is used and YmlContext is not set, some members can get trimmed unexpectedly.";

--- a/Src/GBX.NET.Tool.CLI/ToolConsole.cs
+++ b/Src/GBX.NET.Tool.CLI/ToolConsole.cs
@@ -81,6 +81,13 @@ public class ToolConsole<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
     [RequiresUnreferencedCode(UnreferencedCodeMessage)]
     public static async Task<ToolConsoleRunResult<T>> RunAsync(string[] args, ToolConsoleOptions? options = null)
     {
+        return await RunWithExecuteLogicAsync(args, ExecuteReflectionLogicAsync, options);
+    }
+
+    [RequiresDynamicCode(DynamicCodeMessage)]
+    [RequiresUnreferencedCode(UnreferencedCodeMessage)]
+    public static async Task<ToolConsoleRunResult<T>> RunWithExecuteLogicAsync(string[] args, ExecuteLogic executeLogic, ToolConsoleOptions? options = null)
+    {
         ArgumentNullException.ThrowIfNull(args);
 
         using var http = new HttpClient();
@@ -92,7 +99,7 @@ public class ToolConsole<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
 
         try
         {
-            await tool.RunAsync(ExecuteReflectionLogicAsync, cts.Token);
+            await tool.RunAsync(executeLogic, cts.Token);
         }
         catch (ConsoleProblemException ex)
         {

--- a/Src/GBX.NET.Tool.CLI/ToolConsole.cs
+++ b/Src/GBX.NET.Tool.CLI/ToolConsole.cs
@@ -107,7 +107,7 @@ public class ToolConsole<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
             AnsiConsole.WriteException(ex);
         }
 
-        if (!tool.noPause)
+        if (!tool.noPause && !Console.IsInputRedirected)
         {
             PressAnyKeyToContinue();
         }

--- a/Src/GBX.NET.Tool.CLI/ToolConsole.cs
+++ b/Src/GBX.NET.Tool.CLI/ToolConsole.cs
@@ -1,6 +1,5 @@
 ﻿using GBX.NET.LZO;
 using GBX.NET.Tool.CLI.Exceptions;
-using GBX.NET.Tool.CLI.Inputs;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using System.Diagnostics;
@@ -15,6 +14,8 @@ namespace GBX.NET.Tool.CLI;
 /// <typeparam name="T">Tool type.</typeparam>
 public class ToolConsole<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T> where T : class, ITool
 {
+    private const string DynamicCodeMessage = "Tool instantiation uses MakeGenericType to create collections, but it should work as expected if constructor parameters don't include any IEnumerable-based types. If JsonContext is not set, or YAML is used and YmlContext is not set, this can cause serialization problems with configuration when AOT-compiled.";
+    private const string UnreferencedCodeMessage = "If JsonContext is not set, or YAML is used and YmlContext is not set, some configuration members can get trimmed unexpectedly.";
     private readonly string[] args;
     private readonly HttpClient http;
     private readonly ToolConsoleOptions options;
@@ -76,6 +77,8 @@ public class ToolConsole<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
     /// <param name="args">Command line arguments. Use the 'args' keyword here.</param>
     /// <param name="options">Options for the tool console. These should be hardcoded for purpose.</param>
     /// <returns>Result of the tool execution (if wanted to use later).</returns>
+    [RequiresDynamicCode(DynamicCodeMessage)]
+    [RequiresUnreferencedCode(UnreferencedCodeMessage)]
     public static async Task<ToolConsoleRunResult<T>> RunAsync(string[] args, ToolConsoleOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(args);
@@ -191,6 +194,8 @@ public class ToolConsole<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
         }
     }
 
+    [RequiresDynamicCode(DynamicCodeMessage)]
+    [RequiresUnreferencedCode(UnreferencedCodeMessage)]
     private static async Task ExecuteReflectionLogicAsync(
         ToolSettings toolSettings, 
         SettingsManager settingsManager, 

--- a/Src/GBX.NET.Tool.CLI/ToolConsoleOptions.cs
+++ b/Src/GBX.NET.Tool.CLI/ToolConsoleOptions.cs
@@ -11,7 +11,7 @@ public sealed record ToolConsoleOptions
     {
         WriteIndented = true
     };
-
-    public YamlDotNet.Serialization.IDeserializer? YmlDeserializer { get; init; }
-    public YamlDotNet.Serialization.ISerializer? YmlSerializer { get; init; }
+    public YamlDotNet.Serialization.DeserializerBuilder? YmlDeserializer { get; init; }
+    public YamlDotNet.Serialization.SerializerBuilder? YmlSerializer { get; init; }
+    public YamlDotNet.Serialization.StaticContext? YmlContext { get; init; }
 }

--- a/Src/GBX.NET.Tool.CLI/ToolInstanceMaker.cs
+++ b/Src/GBX.NET.Tool.CLI/ToolInstanceMaker.cs
@@ -132,6 +132,34 @@ internal sealed class ToolInstanceMaker<T> where T : ITool
                 continue;
             }
 
+            if (type == typeof(Stream))
+            {
+                var paramObj = await GetParameterObjectAsync(obj => obj is Stream, cancellationToken);
+
+                if (paramObj is null)
+                {
+                    // Constructor is not valid for this configuration
+                    return null;
+                }
+
+                paramsForCtor[index++] = paramObj;
+                continue;
+            }
+
+            if (type == typeof(TextReader))
+            {
+                var paramObj = await GetParameterObjectAsync(obj => obj is TextReader, cancellationToken);
+
+                if (paramObj is null)
+                {
+                    // Constructor is not valid for this configuration
+                    return null;
+                }
+
+                paramsForCtor[index++] = paramObj;
+                continue;
+            }
+
             if (!type.IsGenericType)
             {
                 return null;

--- a/Src/GBX.NET.Tool.CLI/ToolInstanceMaker.cs
+++ b/Src/GBX.NET.Tool.CLI/ToolInstanceMaker.cs
@@ -14,10 +14,10 @@ internal sealed class ToolInstanceMaker<T> where T : ITool
     
     private readonly ToolFunctionality<T> toolFunctionality;
     private readonly ToolSettings toolSettings;
-    private readonly ComplexConfig complexConfig;
+    private readonly IComplexConfig complexConfig;
     private readonly ILogger logger;
 
-    private readonly Dictionary<Input, object?> resolvedInputs = [];
+    private readonly Dictionary<InputArgument, object?> resolvedInputs = [];
     private readonly HashSet<object> usedObjects = [];
     private readonly List<object> unprocessedObjects = [];
 
@@ -30,7 +30,7 @@ internal sealed class ToolInstanceMaker<T> where T : ITool
         typeof(IReadOnlyList<>),
     ];
 
-    public ToolInstanceMaker(ToolFunctionality<T> toolFunctionality, ToolSettings toolSettings, ComplexConfig complexConfig, ILogger logger)
+    public ToolInstanceMaker(ToolFunctionality<T> toolFunctionality, ToolSettings toolSettings, IComplexConfig complexConfig, ILogger logger)
     {
         this.toolFunctionality = toolFunctionality;
         this.toolSettings = toolSettings;
@@ -249,7 +249,7 @@ internal sealed class ToolInstanceMaker<T> where T : ITool
 
     private async IAsyncEnumerable<object> EnumerateResolvedObjectsAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        foreach (var input in toolSettings.Inputs)
+        foreach (var input in toolSettings.InputArguments)
         {
             // Resolve objects from input and cache them
             if (!resolvedInputs.TryGetValue(input, out var resolvedObject))

--- a/Src/GBX.NET.Tool.CLI/ToolInstanceMaker.cs
+++ b/Src/GBX.NET.Tool.CLI/ToolInstanceMaker.cs
@@ -1,5 +1,5 @@
 ﻿using GBX.NET.Tool.CLI.Exceptions;
-using GBX.NET.Tool.CLI.Inputs;
+using GBX.NET.Tool.CLI.InputArguments;
 using Microsoft.Extensions.Logging;
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;

--- a/Src/GBX.NET.Tool.CLI/ToolSettings.cs
+++ b/Src/GBX.NET.Tool.CLI/ToolSettings.cs
@@ -1,4 +1,4 @@
-﻿using GBX.NET.Tool.CLI.Inputs;
+﻿using GBX.NET.Tool.CLI.InputArguments;
 
 namespace GBX.NET.Tool.CLI;
 

--- a/Src/GBX.NET.Tool.CLI/ToolSettings.cs
+++ b/Src/GBX.NET.Tool.CLI/ToolSettings.cs
@@ -2,9 +2,9 @@
 
 namespace GBX.NET.Tool.CLI;
 
-internal sealed class ToolSettings
+public sealed class ToolSettings
 {
     public ConsoleSettings ConsoleSettings { get; init; } = new();
     public Dictionary<string, string> ConfigOverwrites { get; init; } = [];
-    public IReadOnlyCollection<Input> Inputs { get; init; } = [];
+    public IReadOnlyCollection<InputArgument> InputArguments { get; init; } = [];
 }

--- a/Src/GBX.NET.Tool/IComplexConfig.cs
+++ b/Src/GBX.NET.Tool/IComplexConfig.cs
@@ -4,11 +4,13 @@ namespace GBX.NET.Tool;
 
 public interface IComplexConfig
 {
-    [RequiresDynamicCode("")]
-    [RequiresUnreferencedCode("")]
+    [RequiresUnreferencedCode("This can cause serialization problems when AOT-compiled.")]
+    [RequiresDynamicCode("Some members can get trimmed unexpectedly.")]
     T Get<T>(string filePathWithoutExtension, bool cache = false) where T : class;
+    T GetStatically<T>(string filePathWithoutExtension, bool cache = false) where T : class;
 
-    [RequiresDynamicCode("")]
-    [RequiresUnreferencedCode("")]
+    [RequiresUnreferencedCode("This can cause serialization problems when AOT-compiled.")]
+    [RequiresDynamicCode("Some members can get trimmed unexpectedly.")]
     Task<T> GetAsync<T>(string filePathWithoutExtension, bool cache = false, CancellationToken cancellationToken = default) where T : class;
+    Task<T> GetStaticallyAsync<T>(string filePathWithoutExtension, bool cache = false, CancellationToken cancellationToken = default) where T : class;
 }

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -1207,7 +1207,7 @@ public partial class CGameCtnChallenge :
 
             n.anchoredObjects = r.ReadListNodeRef_deprec<CGameCtnAnchoredObject>()!;
 
-            if (Version >= 1 && Version != 5)
+            if (Version >= 1 && Version != 5 && Version < 8)
             {
                 // defines which (second element) items are deleted together with other (first element) item?
                 var itemsOnItem = r.ReadArray<Int2>();
@@ -1268,11 +1268,6 @@ public partial class CGameCtnChallenge :
                     {
                         throw new NotSupportedException("U07 has something else than -1");
                     }
-                }
-
-                if (Version >= 8)
-                {
-                    return;
                 }
 
                 // always the same count as anchoredObjects

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -1322,7 +1322,7 @@ public partial class CGameCtnChallenge :
                 }
             }
 
-            if (Version >= 1 && Version != 5)
+            if (Version >= 1 && Version != 5 && Version < 8)
             {
                 var pairs = new List<Int2>();
 
@@ -1441,11 +1441,6 @@ public partial class CGameCtnChallenge :
                 if (Version != 6)
                 {
                     itemW.WriteArray(Enumerable.Repeat(-1, usedBlockIndexList.Count).ToArray());
-                }
-
-                if (Version >= 8)
-                {
-                    return;
                 }
 
                 itemW.WriteArray(snappedOnIndices.ToArray());

--- a/Src/GBX.NET/Engines/Plug/CPlugShader.chunkl
+++ b/Src/GBX.NET/Engines/Plug/CPlugShader.chunkl
@@ -55,6 +55,8 @@ CPlugShader 0x09002000
  uint
 
 0x01F
+ version
+ UnknownStruct[]
 
 0x020
  version
@@ -62,3 +64,10 @@ CPlugShader 0x09002000
  float
  CMwNod
  short
+
+archive UnknownStruct
+ CMwNod U01
+ if U01 != null
+  bool U02
+  if U02
+   CMwNod U03

--- a/Src/GBX.NET/Gbx.cs
+++ b/Src/GBX.NET/Gbx.cs
@@ -823,6 +823,126 @@ public partial class Gbx : IGbx
         return ParseClassId(fs, remap);
     }
 
+    public static bool IsUncompressed(Stream stream)
+    {
+        _ = stream ?? throw new ArgumentNullException(nameof(stream));
+
+#if NETSTANDARD2_0
+        var minimalData = new byte[8];
+        var count = stream.Read(minimalData, 0, minimalData.Length);
+#else
+        Span<byte> minimalData = stackalloc byte[8];
+        var count = stream.Read(minimalData);
+#endif
+
+        if (count != minimalData.Length)
+        {
+            throw new NotAGbxException("Not enough data to check if the Gbx is uncompressed.");
+        }
+
+        if (minimalData[0] != 'G' || minimalData[1] != 'B' || minimalData[2] != 'X')
+        {
+            throw new NotAGbxException();
+        }
+
+        return minimalData[7] == (byte)GbxCompression.Uncompressed;
+    }
+
+    public static bool IsUncompressed(string filePath)
+    {
+        using var fs = File.OpenRead(filePath);
+        return IsUncompressed(fs);
+    }
+
+    public static async Task<bool> IsUncompressed(Stream stream, CancellationToken cancellationToken = default)
+    {
+        _ = stream ?? throw new ArgumentNullException(nameof(stream));
+
+        var minimalData = new byte[8];
+#if NETSTANDARD2_0
+        var count = await stream.ReadAsync(minimalData, 0, minimalData.Length, cancellationToken);
+#else
+        var count = await stream.ReadAsync(minimalData, cancellationToken);
+#endif
+        if (count != minimalData.Length)
+        {
+            throw new NotAGbxException("Not enough data to check if the Gbx is uncompressed.");
+        }
+
+        if (minimalData[0] != 'G' || minimalData[1] != 'B' || minimalData[2] != 'X')
+        {
+            throw new NotAGbxException();
+        }
+
+        return minimalData[7] == (byte)GbxCompression.Uncompressed;
+    }
+
+    public static async Task<bool> IsUncompressed(string filePath, CancellationToken cancellationToken = default)
+    {
+        using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
+        return await IsUncompressed(fs, cancellationToken);
+    }
+
+    public static bool IsCompressed(Stream stream)
+    {
+        _ = stream ?? throw new ArgumentNullException(nameof(stream));
+
+#if NETSTANDARD2_0
+        var minimalData = new byte[8];
+        var count = stream.Read(minimalData, 0, minimalData.Length);
+#else
+        Span<byte> minimalData = stackalloc byte[8];
+        var count = stream.Read(minimalData);
+#endif
+
+        if (count != minimalData.Length)
+        {
+            throw new NotAGbxException("Not enough data to check if the Gbx is compressed.");
+        }
+
+        if (minimalData[0] != 'G' || minimalData[1] != 'B' || minimalData[2] != 'X')
+        {
+            throw new NotAGbxException();
+        }
+
+        return minimalData[7] == (byte)GbxCompression.Compressed;
+    }
+
+    public static bool IsCompressed(string filePath)
+    {
+        using var fs = File.OpenRead(filePath);
+        return IsCompressed(fs);
+    }
+
+    public static async Task<bool> IsCompressed(Stream stream, CancellationToken cancellationToken = default)
+    {
+        _ = stream ?? throw new ArgumentNullException(nameof(stream));
+
+        var minimalData = new byte[8];
+#if NETSTANDARD2_0
+        var count = await stream.ReadAsync(minimalData, 0, minimalData.Length, cancellationToken);
+#else
+        var count = await stream.ReadAsync(minimalData, cancellationToken);
+#endif
+        if (count != minimalData.Length)
+        {
+            throw new NotAGbxException("Not enough data to check if the Gbx is compressed.");
+        }
+
+        if (minimalData[0] != 'G' || minimalData[1] != 'B' || minimalData[2] != 'X')
+        {
+            throw new NotAGbxException();
+        }
+
+        return minimalData[7] == (byte)GbxCompression.Compressed;
+    }
+
+    public static async Task<bool> IsCompressed(string filePath, CancellationToken cancellationToken = default)
+    {
+        using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
+        return await IsCompressed(fs, cancellationToken);
+    }
+
     /// <summary>
     /// Implicitly casts <see cref="Gbx"/> to its <see cref="Node"/>.
     /// </summary>


### PR DESCRIPTION
- Added `Gbx.IsCompressed` and `Gbx.IsUncompressed` (throws on non-Gbx data)
- Fixed map item chunk read/write as Nadeo might have changed it a little

Tool framework:
- Refactored tool execution to be possible to generate compile-time in the future
  - Warning can now be eliminated with methods suffixed with `Statically`
- Added stdin support