### PR TITLE
GBX.NET 2.2.1

### DIFF
--- a/Src/GBX.NET.PAK/GBX.NET.PAK.csproj
+++ b/Src/GBX.NET.PAK/GBX.NET.PAK.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <PackageId>GBX.NET.PAK</PackageId>
-        <VersionPrefix>2.1.0</VersionPrefix>
+        <VersionPrefix>2.2.0</VersionPrefix>
         <Authors>BigBang1112</Authors>
         <Description>Support for reading Pak (NadeoPak) package files, integrated with GBX.NET.</Description>
         <Copyright>Copyright (c) 2025 Petr Pivoňka</Copyright>

--- a/Src/GBX.NET/Engines/Game/CGameCtnBlockInfo.chunkl
+++ b/Src/GBX.NET/Engines/Game/CGameCtnBlockInfo.chunkl
@@ -83,9 +83,9 @@ CGameCtnBlockInfo 0x0304E000
   iso4 Sound1Loc
   iso4 Sound2Loc
  v3+
-  if Sound1 != null
+  if Sound1 != null || Sound1File != null
    iso4 Sound1Loc
-  if Sound2 != null
+  if Sound2 != null || Sound2File != null
    iso4 Sound2Loc
 
 0x02B [TMT.v1, MP4.v1]

--- a/Src/GBX.NET/Engines/Game/CGameCtnBlockInfo.chunkl
+++ b/Src/GBX.NET/Engines/Game/CGameCtnBlockInfo.chunkl
@@ -106,7 +106,7 @@ CGameCtnBlockInfo 0x0304E000
 
 0x031
  version
- CMwNod
+ CMwNod (external)
  CPlugGameSkinAndFolder MaterialModifier (external)
  v1+
   CPlugGameSkinAndFolder MaterialModifier2 (external) // not verified

--- a/Src/GBX.NET/Engines/Game/CGameCtnBlockInfo.chunkl
+++ b/Src/GBX.NET/Engines/Game/CGameCtnBlockInfo.chunkl
@@ -45,9 +45,9 @@ CGameCtnBlockInfo 0x0304E000
  v6-
   CGameWaypointSpecialProperty U01
  v2+
-  CGamePodiumInfo PodiumInfo
+  CMwNod PodiumInfo // CGamePodiumInfo or CPlugMediaClipList
   v3+
-   CGamePodiumInfo IntroInfo
+   CMwNod IntroInfo // CGamePodiumInfo or CPlugMediaClipList
    v4+
     bool CharPhySpecialPropertyCustomizable
     v5=

--- a/Src/GBX.NET/Engines/Game/CGameCtnBlockInfoClip.chunkl
+++ b/Src/GBX.NET/Engines/Game/CGameCtnBlockInfoClip.chunkl
@@ -18,6 +18,10 @@ CGameCtnBlockInfoClip 0x03053000
   int<EMultiDir> TopBottomMultiDir
   v2+
    byte?
+   v3+
+    byte?
+    v4+
+     byte?
 
 0x007
  version
@@ -31,6 +35,9 @@ CGameCtnBlockInfoClip 0x03053000
  version
  id ClipGroupId
  id SymmetricalClipGroupId
+ v1+
+  id
+  id
 
 enum EClipType
  ClassicClip

--- a/Src/GBX.NET/Engines/Game/CGameCtnBlockInfoVariant.chunkl
+++ b/Src/GBX.NET/Engines/Game/CGameCtnBlockInfoVariant.chunkl
@@ -87,7 +87,7 @@ CGameCtnBlockInfoVariant 0x0315B000
 
 0x00B [MP4.v1]
  version
- WaterVolume[] WaterVolumes
+ WaterVolume[] WaterVolumes (version: Version)
 
 0x00C [MP4.v1]
  version

--- a/Src/GBX.NET/Engines/Game/CGameCtnBlockInfoVariant.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnBlockInfoVariant.cs
@@ -1,15 +1,29 @@
-﻿namespace GBX.NET.Engines.Game;
+﻿using GBX.NET.Components;
+
+namespace GBX.NET.Engines.Game;
 
 public partial class CGameCtnBlockInfoVariant
 {
     public CGameCtnBlockInfoMobil[][]? Mobils { get; set; }
 
+    private CPlugSolid? helperSolidFid;
+    [AppliedWithChunk<Chunk0315B005>]
+    public CPlugSolid? HelperSolidFid { get => helperSolidFidFile?.GetNode(ref helperSolidFid) ?? helperSolidFid; set => helperSolidFid = value; }
+    private GbxRefTableFile? helperSolidFidFile;
+    public GbxRefTableFile? HelperSolidFidFile { get => helperSolidFidFile; set => helperSolidFidFile = value; }
+    public CPlugSolid? GetHelperSolidFid(GbxReadSettings settings = default, bool exceptions = false) => helperSolidFidFile?.GetNode(ref helperSolidFid, settings, exceptions) ?? helperSolidFid;
+
+    private CPlugSolid? facultativeHelperSolidFid;
+    [AppliedWithChunk<Chunk0315B005>]
+    public CPlugSolid? FacultativeHelperSolidFid { get => facultativeHelperSolidFidFile?.GetNode(ref facultativeHelperSolidFid) ?? facultativeHelperSolidFid; set => facultativeHelperSolidFid = value; }
+    private GbxRefTableFile? facultativeHelperSolidFidFile;
+    public GbxRefTableFile? FacultativeHelperSolidFidFile { get => facultativeHelperSolidFidFile; set => facultativeHelperSolidFidFile = value; }
+    public CPlugSolid? GetFacultativeHelperSolidFid(GbxReadSettings settings = default, bool exceptions = false) => facultativeHelperSolidFidFile?.GetNode(ref facultativeHelperSolidFid, settings, exceptions) ?? facultativeHelperSolidFid;
+
     public partial class Chunk0315B005 : IVersionable
     {
         public int Version { get; set; }
 
-        public int U01;
-        public int U02;
         public int U03;
 
         public override void Read(CGameCtnBlockInfoVariant n, GbxReader r)
@@ -24,8 +38,8 @@ public partial class CGameCtnBlockInfoVariant
 
             if (Version >= 2)
             {
-                U01 = r.ReadInt32(); // HelperSolidFid?
-                U02 = r.ReadInt32(); // FacultativeHelperSolidFid?
+                n.helperSolidFid = r.ReadNodeRef<CPlugSolid>(out n.helperSolidFidFile); // HelperSolidFid?
+                n.facultativeHelperSolidFid = r.ReadNodeRef<CPlugSolid>(out n.facultativeHelperSolidFidFile); // FacultativeHelperSolidFid?
 
                 if (Version >= 3)
                 {
@@ -46,8 +60,8 @@ public partial class CGameCtnBlockInfoVariant
 
             if (Version >= 2)
             {
-                w.Write(U01);
-                w.Write(U02);
+                w.WriteNodeRef(n.helperSolidFid, n.helperSolidFidFile);
+                w.WriteNodeRef(n.facultativeHelperSolidFid, n.facultativeHelperSolidFidFile);
 
                 if (Version >= 3)
                 {

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -956,14 +956,14 @@ public partial class CGameCtnChallenge :
                     return sb.ToString();
                 }
             default:
-                throw new NotSupportedException($"Game version {version} is not supported for header XML generation.");
+                throw new NotSupportedException($"Game version {gameVersion} is not supported for header XML generation.");
         }
 
         void AppendMediaTrackerDeps(StringBuilder sb)
         {
             foreach (var block in ClipIntro?.Tracks
-                .Concat(ClipGroupInGame.Clips.SelectMany(x => x.Clip.Tracks))
-                .Concat(ClipGroupEndRace.Clips.SelectMany(x => x.Clip.Tracks))
+                .Concat(ClipGroupInGame?.Clips.SelectMany(x => x.Clip.Tracks) ?? [])
+                .Concat(ClipGroupEndRace?.Clips.SelectMany(x => x.Clip.Tracks) ?? [])
                 .Concat(ClipGlobal?.Tracks ?? [])
                 .Concat(ClipAmbiance?.Tracks ?? [])
                 .SelectMany(x => x.Blocks) ?? [])

--- a/Src/GBX.NET/Engines/Game/CGameCtnCollection.chunkl
+++ b/Src/GBX.NET/Engines/Game/CGameCtnCollection.chunkl
@@ -49,6 +49,10 @@ CGameCtnCollection 0x03033000
     string FolderMacroBlockInfo
     v4+
      string FolderMacroDecals
+     v5+
+      string
+      v6+
+       string
 
 0x003 (header, struct: SHeaderMenuIconsFolders)
  versionb
@@ -206,27 +210,33 @@ CGameCtnCollection 0x03033000
 
 0x038
  version
- v3-
-  float
-  v0=
+ v7-
+  v3-
    float
-   float
-  v1+
+   v0=
+    float
+    float
+   v1+
+    Water Water1 (version: Version)
+    Water Water2 (version: Version)
+  v4+
    Water Water1 (version: Version)
    Water Water2 (version: Version)
- v4+
-  Water Water1 (version: Version)
-  Water Water2 (version: Version)
-  Water Water3 (version: Version)
-  Water Water4 (version: Version)
-  v5+
-   CPlugBitmap WaterGBitmapNormal (external)
-   float WaterGBumpSpeedUV
-   float WaterGBumpScaleUV
-   float WaterGBumpScale
-   float WaterGRefracPertub
-   v7+
-    int // not seen in code
+   Water Water3 (version: Version)
+   Water Water4 (version: Version)
+ v8+
+  CPlugMaterialWaterArray WaterArray
+  if WaterArray == null
+   int
+   Water Water1 (version: Version)
+ v5+
+  CPlugBitmap WaterGBitmapNormal (external)
+  float WaterGBumpSpeedUV
+  float WaterGBumpScaleUV
+  float WaterGBumpScale
+  float WaterGRefracPertub
+  v7+
+   int // not seen in code
  float CameraMinHeight
  v3-
   bool // CSystemFidsFolder something?
@@ -244,29 +254,37 @@ CGameCtnCollection 0x03033000
  v1+
   int? // VehicleStyles?
   v2+
-   CMwNod ItemPlacementGroups
+   CMwNod ItemPlacementGroups (external)
    v3+
     CMwNod AdnRandomGenList
     v4+
-     CMwNod FidBlockInfoGroups
+     CMwNod FidBlockInfoGroups (external)
      v10-
       CMwNod
       v8+
        CMwNod
      v6+
-      CMwNod
+      CMwNod FidBlockInfoInventory (external)
      v8-
       CMwNod
      v10+
-      CMwNod
+      CMwNod FidItemModelInventory (external)
       v12+
-       CMwNod
+       CPlugBitmap (external)
       v11+
-       CMwNod
-       CMwNod
-       CMwNod
-       CMwNod
-       CMwNod
+       CPlugBitmap (external)
+       CPlugBitmap (external)
+       CPlugBitmap (external)
+       CPlugBitmap (external)
+       CMwNod (external)
+       v13+
+        CMwNod FidMacroBlockInfoInventory (external)
+        v14+
+         CPlugMediaClipList DefaultSpawnClipList (external)
+         v18+ // guessed, not in my latest decompile
+          ident // CarSnow
+          ident // CarRally
+          ident // CarDesert
 
 0x03A
  version
@@ -290,6 +308,8 @@ CGameCtnCollection 0x03033000
  v1+
   uint? TurboColorTurbo
   uint? TurboColorTurbo2
+  v2+
+   int?
 
 0x03C
  version
@@ -299,11 +319,32 @@ CGameCtnCollection 0x03033000
 
 0x03D // BitmapDisplayControlDefaultTVProgram
  version
- CPlugBitmap BitmapDisplayControlDefaultTVProgram16x9
- CPlugBitmap BitmapDisplayControlDefaultTVProgram64x10A
- CPlugBitmap BitmapDisplayControlDefaultTVProgram64x10B
- CPlugBitmap BitmapDisplayControlDefaultTVProgram64x10C
- CPlugBitmap BitmapDisplayControlDefaultTVProgram2x3
+ CPlugBitmap BitmapDisplayControlDefaultTVProgram16x9 (external)
+ CPlugBitmap BitmapDisplayControlDefaultTVProgram64x10A (external)
+ CPlugBitmap BitmapDisplayControlDefaultTVProgram64x10B (external)
+ CPlugBitmap BitmapDisplayControlDefaultTVProgram64x10C (external)
+ CPlugBitmap BitmapDisplayControlDefaultTVProgram2x3 (external)
+
+0x03E
+ version
+ int
+
+0x03F
+ version
+ int
+
+0x040
+ version
+ CPlugGameSkinAndFolder ColorBlindnessModifier (external)
+
+0x041
+ string
+
+0x042
+ int
+
+0x043
+ string
 
 enum ECollectionType
  Environment
@@ -334,6 +375,6 @@ archive Water
  v3+
   float?
  v2+
-  CMwNod
+  CMwNod (external)
   v7+
    int? // not seen in code

--- a/Src/GBX.NET/Engines/GameData/CGameVehicleModel.chunkl
+++ b/Src/GBX.NET/Engines/GameData/CGameVehicleModel.chunkl
@@ -5,6 +5,10 @@ CGameVehicleModel 0x2E01C000
  CPlugVehiclePhyModel PhyModel (external)
  CPlugVehicleVisModel VisModel (external)
  ItemOccupantSlotModel[] ItemOccupantSlotModels
+ v1+
+  CGameObjectModel[]
+  v2=
+   CMwNod
 
 archive ItemOccupantSlotModel
  id Id

--- a/Src/GBX.NET/Engines/Graphic/GxLightSpot.chunkl
+++ b/Src/GBX.NET/Engines/Graphic/GxLightSpot.chunkl
@@ -15,3 +15,18 @@ GxLightSpot 0x0400B000
  float AngleInnerShadow
  float AngleOuterShadow
  float FalloffExponent
+
+0x003
+ version
+ uint Flags
+ float AngleInner
+ float AngleOuter
+ float AngleFlare
+ float AngleInnerShadow
+ float AngleOuterShadow
+ float FalloffExponent
+ v1+
+  byte
+  byte
+ v0=
+  int

--- a/Src/GBX.NET/Engines/Plug/CPlugBitmap.chunkl
+++ b/Src/GBX.NET/Engines/Plug/CPlugBitmap.chunkl
@@ -107,6 +107,42 @@ CPlugBitmap 0x09011000
    v3+
     CPlugBitmapArray BitmapArray
     string BitmapArrayElemName
+    v4=
+     int
+
+0x035
+ version
+ short
+
+0x036
+ version
+ CMwNod U01
+ v0=
+  id U02
+ v1+
+  if U01 == null
+   id U02
+  if U01 != null
+   vec2 U03
+   vec2 U04
+   int U05
+ CMwNod U06
+
+0x037
+ version
+ int
+ int
+ int
+ int
+ int
+ int
+ int
+ int
+
+0x038
+ version
+ CPlugBitmapAtlas
+ int
 
 enum EUsage
  Color

--- a/Src/GBX.NET/Engines/Plug/CPlugBitmap.chunkl
+++ b/Src/GBX.NET/Engines/Plug/CPlugBitmap.chunkl
@@ -79,16 +79,6 @@ CPlugBitmap 0x09011000
  int
 
 0x030
- version
- CPlugFileImg Image (external)
- v1+
-  int3
- float MipMapLowerAlpha
- float BumpScaleFactor
- float MipMapLodBiasDefault
- int BorderRGB
- if Image != null
-  CMwNod
 
 0x032
  version

--- a/Src/GBX.NET/Engines/Plug/CPlugBitmap.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugBitmap.cs
@@ -1,0 +1,35 @@
+﻿namespace GBX.NET.Engines.Plug;
+
+public partial class CPlugBitmap
+{
+    public partial class Chunk09011030 : IVersionable
+    {
+        public int Version { get; set; }
+
+        public Int3 U01;
+        public CMwNod? U02;
+        public CMwNod? U03;
+
+        public override void ReadWrite(CPlugBitmap n, GbxReaderWriter rw)
+        {
+            rw.VersionInt32(this);
+            n.image = (CPlugFileImg?)rw.NodeRef((CMwNod?)n.image, ref n.imageFile);
+            if (Version >= 1)
+            {
+                rw.Int3(ref U01);
+            }
+            if (Version == 2)
+            {
+                rw.NodeRef<CMwNod>(ref U02);
+            }
+            rw.Single(ref n.mipMapLowerAlpha);
+            rw.Single(ref n.bumpScaleFactor);
+            rw.Single(ref n.mipMapLodBiasDefault);
+            rw.Int32(ref n.borderRGB);
+            if (n.Image != null)
+            {
+                rw.NodeRef<CMwNod>(ref U03);
+            }
+        }
+    }
+}

--- a/Src/GBX.NET/Engines/Plug/CPlugFileGen.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugFileGen.cs
@@ -1,0 +1,16 @@
+﻿namespace GBX.NET.Engines.Plug;
+
+public partial class CPlugFileGen
+{
+#if NET8_0_OR_GREATER
+    static void IClass.Read<T>(T node, GbxReaderWriter rw)
+    {
+        node.ReadWrite(rw);
+    }
+#endif
+
+    public override void ReadWrite(GbxReaderWriter rw)
+    {
+        throw new NotSupportedException("CPlugFileGen is not yet supported");
+    }
+}

--- a/Src/GBX.NET/Engines/Plug/CPlugGameSkinAndFolder.chunkl
+++ b/Src/GBX.NET/Engines/Plug/CPlugGameSkinAndFolder.chunkl
@@ -1,1 +1,6 @@
 CPlugGameSkinAndFolder 0x0915D000
+
+0x000 (ignore)
+
+0x001
+ id

--- a/Src/GBX.NET/Engines/Plug/CPlugMaterial.chunkl
+++ b/Src/GBX.NET/Engines/Plug/CPlugMaterial.chunkl
@@ -38,10 +38,16 @@ CPlugMaterial 0x09079000
 
 0x015
  version
- int
- int[]
- v7+
-  CMwNod
+ CPlug Shader (external)
+ if Shader == null && ShaderFile == null
+  DeviceMat[] DeviceMaterials (version: 0x015)
+  int
+  v3+
+   int
+ if Shader != null || ShaderFile != null
+  CPlugMaterialColorTargetTable[]
+  v7+
+   CMwNod
 
 0x016
  version

--- a/Src/GBX.NET/Engines/Plug/CPlugMaterial.chunkl
+++ b/Src/GBX.NET/Engines/Plug/CPlugMaterial.chunkl
@@ -41,7 +41,7 @@ CPlugMaterial 0x09079000
  CPlug Shader (external)
  if Shader == null && ShaderFile == null
   DeviceMat[] DeviceMaterials (version: 0x015)
-  int
+  int[]
   v3+
    int
  if Shader != null || ShaderFile != null

--- a/Src/GBX.NET/Engines/Plug/CPlugMaterial.chunkl
+++ b/Src/GBX.NET/Engines/Plug/CPlugMaterial.chunkl
@@ -36,6 +36,27 @@ CPlugMaterial 0x09079000
 
 0x014 (skippable, ignore)
 
+0x015
+ version
+ int
+ int[]
+ v7+
+  CMwNod
+
+0x016
+ version
+ uint
+
+0x017
+ version
+ uint
+ v1+
+  int
+  int
+  string
+
+0x019 (skippable, ignore)
+
 archive DeviceMat
  short
  short

--- a/Src/GBX.NET/Engines/Plug/CPlugMaterial.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugMaterial.cs
@@ -2,13 +2,6 @@
 
 public partial class CPlugMaterial
 {
-    private CPlug? shader;
-    [AppliedWithChunk<Chunk0907900D>]
-    public CPlug? Shader { get => shaderFile?.GetNode(ref shader) ?? shader; set => shader = value; } // probably m_Material
-    private Components.GbxRefTableFile? shaderFile;
-    public Components.GbxRefTableFile? ShaderFile { get => shaderFile; set => shaderFile = value; }
-    public CPlug? GetShader(GbxReadSettings settings = default, bool exceptions = false) => shaderFile?.GetNode(ref shader, settings, exceptions) ?? shader;
-
     private DeviceMat[]? deviceMaterials;
     [AppliedWithChunk<Chunk0907900D>]
     public DeviceMat[]? DeviceMaterials { get => deviceMaterials; set => deviceMaterials = value; }

--- a/Src/GBX.NET/Engines/Plug/CPlugMaterialCustom.chunkl
+++ b/Src/GBX.NET/Engines/Plug/CPlugMaterialCustom.chunkl
@@ -61,6 +61,19 @@ CPlugMaterialCustom 0x0903A000
  if U01 == 0
   string
   string
+  v2+
+   string
+   string
+
+0x016
+ version
+ ulong U01
+ ulong U02
+ v1+
+  int U03
+ if (U01 & 1) != 0
+  short U04
+  short U05
 
 archive Bitmap
  id Name

--- a/Src/GBX.NET/Engines/Plug/CPlugMaterialWaterArray.chunkl
+++ b/Src/GBX.NET/Engines/Plug/CPlugMaterialWaterArray.chunkl
@@ -1,0 +1,1 @@
+CPlugMaterialWaterArray 0x0917D000

--- a/Src/GBX.NET/Engines/Plug/CPlugMediaClipList.chunkl
+++ b/Src/GBX.NET/Engines/Plug/CPlugMediaClipList.chunkl
@@ -1,5 +1,5 @@
 CPlugMediaClipList 0x09189000
 
 0x000
- int
- CMwNod[] MediaClipFids // (external)
+ version
+ CMwNod[] MediaClipFids (external)

--- a/Src/GBX.NET/Engines/Plug/CPlugPointsInSphereOpt.chunkl
+++ b/Src/GBX.NET/Engines/Plug/CPlugPointsInSphereOpt.chunkl
@@ -1,1 +1,9 @@
 CPlugPointsInSphereOpt 0x09066000
+
+0x000
+ Pack[] Packs
+ vec3[]
+
+archive Pack
+ int
+ int

--- a/Src/GBX.NET/Engines/Plug/CPlugPolyLine3.chunkl
+++ b/Src/GBX.NET/Engines/Plug/CPlugPolyLine3.chunkl
@@ -15,8 +15,10 @@ CPlugPolyLine3 0x09118000
    bool
    v5+
     bool
-    v7+
-     byte
-     v8+
+    v6+
+     int
+     v7+
       byte
-      id
+      v8+
+       byte
+       id

--- a/Src/GBX.NET/Engines/Plug/CPlugRoadChunk.chunkl
+++ b/Src/GBX.NET/Engines/Plug/CPlugRoadChunk.chunkl
@@ -1,33 +1,3 @@
 CPlugRoadChunk 0x09128000
 
-0x000
- version
- int
- int
- vec3[]
- vec3[]
- vec3[]
- v2+
-  int
-  vec3[]
-  v3+
-   int
-   v5+
-    byte
-    byte
-    v6+
-     float
-     float
-     v7+
-      byte
-      v8+
-       id
-       v9+
-        int[]
-        v10+
-         byte
-         id
-         v11+
-          vec3
-          v12+
-           float
+0x000 (demonstation)

--- a/Src/GBX.NET/Engines/Plug/CPlugRoadChunk.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugRoadChunk.cs
@@ -1,0 +1,105 @@
+﻿namespace GBX.NET.Engines.Plug;
+
+public partial class CPlugRoadChunk
+{
+    public partial class Chunk09128000 : IVersionable
+    {
+        public int Version { get; set; }
+
+        public int U01;
+        public int U02;
+        public Vec3[]? U03;
+        public Vec3[]? U04;
+        public Vec3[]? U05;
+        public int U06;
+        public Vec3[]? U07;
+        public int U08;
+        public byte U09;
+        public byte U10;
+        public float U11;
+        public float U12;
+        public byte U13;
+        public string? U14;
+        public Vec3[][]? U15;
+        public byte U16;
+        public string? U17;
+        public Vec3 U18;
+        public Quat U19;
+
+        public override void ReadWrite(CPlugRoadChunk n, GbxReaderWriter rw)
+        {
+            rw.VersionInt32(this);
+            rw.Int32(ref U01);
+            rw.Int32(ref U02);
+            rw.Array<Vec3>(ref U03!);
+            rw.Array<Vec3>(ref U04!);
+            rw.Array<Vec3>(ref U05!);
+            if (Version >= 2)
+            {
+                rw.Int32(ref U06);
+                rw.Array<Vec3>(ref U07!);
+                if (Version >= 3)
+                {
+                    rw.Int32(ref U08);
+                    if (Version >= 5)
+                    {
+                        rw.Byte(ref U09);
+                        rw.Byte(ref U10);
+                        if (Version >= 6)
+                        {
+                            rw.Single(ref U11);
+                            rw.Single(ref U12);
+                            if (Version >= 7)
+                            {
+                                rw.Byte(ref U13);
+                                if (Version >= 8)
+                                {
+                                    rw.Id(ref U14);
+                                    if (Version >= 9)
+                                    {
+                                        if (rw.Reader is not null)
+                                        {
+                                            var count = rw.Reader.ReadInt32();
+                                            U15 = new Vec3[count][];
+
+                                            for (var i = 0; i < count; i++)
+                                            {
+                                                U15[i] = rw.Reader.ReadArray<Vec3>();
+                                            }
+                                        }
+                                        else if (rw.Writer is not null)
+                                        {
+                                            rw.Writer.Write(U15?.Length ?? 0);
+
+                                            if (U15 is not null)
+                                            {
+                                                foreach (var array in U15)
+                                                {
+                                                    rw.Writer.WriteArray(array);
+                                                }
+                                            }
+                                        }
+
+                                        if (Version >= 10)
+                                        {
+                                            rw.Byte(ref U16);
+                                            rw.Id(ref U17);
+                                            if (Version == 11)
+                                            {
+                                                rw.Vec3(ref U18);
+                                            }
+                                            if (Version >= 12)
+                                            {
+                                                rw.Quat(ref U19);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Src/GBX.NET/Engines/Plug/CPlugShaderApply.chunkl
+++ b/Src/GBX.NET/Engines/Plug/CPlugShaderApply.chunkl
@@ -49,3 +49,9 @@ CPlugShaderApply 0x09026000
 0x011
  version
  CMwNod (external)
+
+0x012
+ version
+ uint
+ uint
+ uint

--- a/Src/GBX.NET/Engines/Plug/CPlugShaderPass.chunkl
+++ b/Src/GBX.NET/Engines/Plug/CPlugShaderPass.chunkl
@@ -32,6 +32,13 @@ CPlugShaderPass 0x09067000
 0x00C
  uint
 
+0x00D
+ UnknownStruct[]
+ UnknownStruct[]
+ UnknownStruct[]
+ UnknownStruct[]
+ UnknownStruct[]
+
 archive PipelineGpu
  bool U01
  CMwNod Script (external)
@@ -46,3 +53,7 @@ archive GpuLoadFx
  int
  int
  int
+
+archive UnknownStruct
+ CPlugBitmap (external)
+ id

--- a/Src/GBX.NET/Engines/Plug/CPlugSolid.chunkl
+++ b/Src/GBX.NET/Engines/Plug/CPlugSolid.chunkl
@@ -105,6 +105,10 @@ CPlugSolid 0x09005000
    iso4[]
    v3+
     string
+    v4+
+     int
+     v5+
+      CPlugPath
 
 0x01A (skippable, ignore) // lod normal map
 

--- a/Src/GBX.NET/Engines/Plug/CPlugSolid.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugSolid.cs
@@ -16,4 +16,34 @@ public partial class CPlugSolid
 
         ExportToObj(objWriter, mtlWriter, mergeVerticesDigitThreshold, lod);
     }
+
+    public IEnumerable<CPlugTree> GetAllChildren(bool includeVisualMipLevels = false)
+    {
+        if (Tree is not CPlugTree tree)
+        {
+            yield break;
+        }
+
+        yield return tree;
+
+        foreach (var child in tree.GetAllChildren(includeVisualMipLevels))
+        {
+            yield return child;
+        }
+    }
+
+    public IEnumerable<(CPlugTree Tree, Iso4 Location)> GetAllChildrenWithLocation(int lod = 0)
+    {
+        if (Tree is not CPlugTree tree)
+        {
+            yield break;
+        }
+
+        yield return (tree, tree.Location ?? Iso4.Identity);
+
+        foreach (var pair in tree.GetAllChildrenWithLocation(lod))
+        {
+            yield return pair;
+        }
+    }
 }

--- a/Src/GBX.NET/Engines/Plug/CPlugTree.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugTree.cs
@@ -111,9 +111,9 @@ public partial class CPlugTree
                 a.ZX * b.XY + a.ZY * b.YY + a.ZZ * b.ZY,
                 a.ZX * b.XZ + a.ZY * b.YZ + a.ZZ * b.ZZ,
 
-                a.TX + b.TX,
-                a.TY + b.TY,
-                a.TZ + b.TZ
+                a.XX * b.TX + a.XY * b.TY + a.XZ * b.TZ + a.TX,
+                a.YX * b.TX + a.YY * b.TY + a.YZ * b.TZ + a.TY,
+                a.ZX * b.TX + a.ZY * b.TY + a.ZZ * b.TZ + a.TZ
             );
         }
 

--- a/Src/GBX.NET/Engines/Plug/CPlugTree.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugTree.cs
@@ -30,6 +30,8 @@ public partial class CPlugTree
 
             foreach (var child in tree.Children)
             {
+                yield return child;
+
                 if (includeVisualMipLevels && child is CPlugTreeVisualMip mip)
                 {
                     foreach (var level in mip.Levels)
@@ -39,11 +41,7 @@ public partial class CPlugTree
                             yield return descendant;
                         }
                     }
-
-                    continue;
                 }
-
-                yield return child;
 
                 foreach (var descendant in GetAllChildren(child, includeVisualMipLevels))
                 {

--- a/Src/GBX.NET/Engines/Plug/CPlugVertexStream.cs
+++ b/Src/GBX.NET/Engines/Plug/CPlugVertexStream.cs
@@ -54,7 +54,7 @@ public partial class CPlugVertexStream
 
             rw.Boolean(ref U01);
 
-            foreach (var decl in n.dataDecls)
+            foreach (var decl in n.dataDecls ?? [])
             {
                 switch (decl.Type)
                 {

--- a/Src/GBX.NET/Engines/Plug/NPlugTrigger_SSpecial.chunkl
+++ b/Src/GBX.NET/Engines/Plug/NPlugTrigger_SSpecial.chunkl
@@ -1,0 +1,5 @@
+NPlugTrigger_SSpecial 0x09179000
+
+archive
+ version
+ CPlugSurface TriggerShape (external)

--- a/Src/GBX.NET/Engines/Plug/NPlugTrigger_SSpecial.cs
+++ b/Src/GBX.NET/Engines/Plug/NPlugTrigger_SSpecial.cs
@@ -1,0 +1,18 @@
+﻿namespace GBX.NET.Engines.Plug;
+
+public partial class NPlugTrigger_SSpecial : IVersionable
+{
+    public int Version { get; set; }
+
+#if NET8_0_OR_GREATER
+    static void IClass.Read<T>(T node, GbxReaderWriter rw)
+    {
+        node.ReadWrite(rw);
+    }
+#endif
+
+    public override void ReadWrite(GbxReaderWriter rw)
+    {
+        ReadWrite(rw, v: 0);
+    }
+}

--- a/Src/GBX.NET/Engines/Scene/CSceneVehicleCar.Sample.cs
+++ b/Src/GBX.NET/Engines/Scene/CSceneVehicleCar.Sample.cs
@@ -51,7 +51,7 @@ public partial class CSceneVehicleCar
             }
         }
 
-        public bool U26_FL_2 => (U26 & 0x80) != 0;
+        public bool FLOnGround => (U26 & 0x80) != 0;
         public byte U27 { get; set; }
         public bool FRIsSliding
         {
@@ -63,7 +63,7 @@ public partial class CSceneVehicleCar
             }
         }
 
-        public bool U27_FR_2 => (U27 & 0x02) != 0;
+        public bool FROnGround => (U27 & 0x02) != 0;
         public bool RRIsSliding
         {
             get => (U27 & 0x04) != 0;
@@ -74,7 +74,7 @@ public partial class CSceneVehicleCar
             }
         }
 
-        public bool U27_RR_4 => (U27 & 0x08) != 0;
+        public bool RROnGround => (U27 & 0x08) != 0;
         public bool RLIsSliding
         {
             get => (U27 & 0x10) != 0;
@@ -85,7 +85,7 @@ public partial class CSceneVehicleCar
             }
         }
 
-        public bool U27_RL_6 => (U27 & 0x20) != 0;
+        public bool RLOnGround => (U27 & 0x20) != 0;
         public bool U27_7 => (U27 & 0x40) != 0;
         public bool U27_8 => (U27 & 0x80) != 0;
         public float? DirtBlend { get; set; }

--- a/Src/GBX.NET/Engines/Scene/CSceneVehicleCar.Sample.cs
+++ b/Src/GBX.NET/Engines/Scene/CSceneVehicleCar.Sample.cs
@@ -41,14 +41,50 @@ public partial class CSceneVehicleCar
         public byte U25_3 => (byte)((U25 >> 5) & 3);
         public bool U25_4 => (U25 >> 7) != 0;
         public byte U26 { get; set; }
-        public bool FLIsSliding => (U26 & 0x40) != 0;
+        public bool FLIsSliding
+        {
+            get => (U26 & 0x40) != 0;
+            set
+            {
+                if (value) U26 |= 0x40;
+                else U26 &= 0xBF; // 0b10111111
+            }
+        }
+
         public bool U26_FL_2 => (U26 & 0x80) != 0;
         public byte U27 { get; set; }
-        public bool FRIsSliding => (U27 & 0x01) != 0;
+        public bool FRIsSliding
+        {
+            get => (U27 & 0x01) != 0;
+            set
+            {
+                if (value) U27 |= 0x01;
+                else U27 &= 0xFE; // 0b11111110
+            }
+        }
+
         public bool U27_FR_2 => (U27 & 0x02) != 0;
-        public bool RRIsSliding => (U27 & 0x04) != 0;
+        public bool RRIsSliding
+        {
+            get => (U27 & 0x04) != 0;
+            set
+            {
+                if (value) U27 |= 0x04;
+                else U27 &= 0xFB; // 0b11111011
+            }
+        }
+
         public bool U27_RR_4 => (U27 & 0x08) != 0;
-        public bool RLIsSliding => (U27 & 0x10) != 0;
+        public bool RLIsSliding
+        {
+            get => (U27 & 0x10) != 0;
+            set
+            {
+                if (value) U27 |= 0x10;
+                else U27 &= 0xEF; // 0b11101111
+            }
+        }
+
         public bool U27_RL_6 => (U27 & 0x20) != 0;
         public bool U27_7 => (U27 & 0x40) != 0;
         public bool U27_8 => (U27 & 0x80) != 0;
@@ -93,8 +129,16 @@ public partial class CSceneVehicleCar
                 FRGroundContactMaterial = CPlugSurface.MaterialId.Asphalt;
                 RRGroundContactMaterial = CPlugSurface.MaterialId.Asphalt;
                 RLGroundContactMaterial = CPlugSurface.MaterialId.Asphalt;
+
                 var netData = r.ReadUInt16();
+
                 Brake = netData >> 1 & 1;
+
+                var isSliding = (netData >> 2 & 1) != 0;
+                FLIsSliding = isSliding;
+                FRIsSliding = isSliding;
+                RRIsSliding = isSliding;
+                RLIsSliding = isSliding;
 
                 // Calculate RPM
                 var min = 100f; // guessed cuz its stored by vehicle

--- a/Src/GBX.NET/GBX.NET.csproj
+++ b/Src/GBX.NET/GBX.NET.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <PackageId>GBX.NET</PackageId>
-        <VersionPrefix>2.2.0</VersionPrefix>
+        <VersionPrefix>2.2.1</VersionPrefix>
         <Authors>BigBang1112</Authors>
         <Description>General purpose library for Gbx files - data from Nadeo games like Trackmania or Shootmania. It supports high performance serialization and deserialization of 400+ Gbx classes.</Description>
         <Copyright>Copyright (c) 2025 Petr Pivoňka</Copyright>


### PR DESCRIPTION
- Added `HelperSolidFid` and `FacultativeHelperSolidFid` to `CGameCtnBlockInfoVariant`
- Added per-wheel `OnGround` property to ghost samples
- Improved support for `CGameCtnChallenge.CreateHeaderXml`
- Fixed `CGameCtnMediaBlockCameraOrbital` for TMF (by @SuperKulPerson)
- Fixed `CPlugTree.GetAllChildren` not properly scrolling mips
- Fixed various transformation issues when flattening `CPlugTree`
- Fixed `CGameCtnCollection` and `CGameCtnBlockInfo` for TM2020
- Further mesh and material support for TM2020