### PR TITLE
2.4.1

### DIFF
--- a/Src/GBX.NET/Engines/Control/CControlList.chunkl
+++ b/Src/GBX.NET/Engines/Control/CControlList.chunkl
@@ -1,7 +1,15 @@
 CControlList 0x0700F000
 - inherits: CControlContainer
 
-0x007 (ignore)
+0x007
+ int
+ int
+ int
+ int
+ int
+ int
+ int
+ Unknown[]
 
 0x00A
  float
@@ -14,4 +22,11 @@ CControlList 0x0700F000
   CMwNod
  float
  float
+ bool
+
+archive Unknown
+ string
+ float
+ CMwNod
+ id
  bool

--- a/Src/GBX.NET/Engines/Game/CGameGhost.Data.cs
+++ b/Src/GBX.NET/Engines/Game/CGameGhost.Data.cs
@@ -160,8 +160,12 @@ public partial class CGameGhost
                 }
             }
 
-            // CGameGhostTMData::ArchiveStateTimes
-            stateTimes = r.ReadArray<int>();
+            // guessed. there's some difference between TM1 and TM2 here, pls investigate soon
+            if (Version >= 10 || !IsFixedTimeStep)
+            {
+                // CGameGhostTMData::ArchiveStateTimes
+                stateTimes = r.ReadArray<int>();
+            }
 
             if (r.BaseStream.Position != r.BaseStream.Length)
             {
@@ -264,8 +268,11 @@ public partial class CGameGhost
                 }
             }
 
-            // CGameGhostTMData::ArchiveStateTimes
-            w.WriteArray(stateTimes);
+            if (Version >= 10 || !IsFixedTimeStep)
+            {
+                // CGameGhostTMData::ArchiveStateTimes
+                w.WriteArray(stateTimes);
+            }
         }
 
         private Sample ReadSample(TimeInt32 time, byte[] sampleData)

--- a/Src/GBX.NET/Engines/Hms/CHmsItem.cs
+++ b/Src/GBX.NET/Engines/Hms/CHmsItem.cs
@@ -1,0 +1,9 @@
+﻿namespace GBX.NET.Engines.Hms;
+
+public partial class CHmsItem
+{
+    protected override bool OnRawChunkIdRead(uint rawChunkId)
+    {
+        return rawChunkId != 0;
+    }
+}

--- a/Src/GBX.NET/Engines/MwFoundations/CMwNod.cs
+++ b/Src/GBX.NET/Engines/MwFoundations/CMwNod.cs
@@ -528,6 +528,11 @@ public partial class CMwNod : IClass
         return Chunks.Create<T>();
     }
 
+    public bool TryCreateChunk<T>(out T chunk) where T : IChunk, new()
+    {
+        return Chunks.TryCreate<T>(out chunk);
+    }
+
     public T? GetChunk<T>() where T : IChunk
     {
         return Chunks.Get<T>();

--- a/Src/GBX.NET/Engines/MwFoundations/CMwNod.cs
+++ b/Src/GBX.NET/Engines/MwFoundations/CMwNod.cs
@@ -34,6 +34,11 @@ public partial class CMwNod : IClass
         {
             var rawChunkId = r.ReadHexUInt32();
 
+            if (!OnRawChunkIdRead(rawChunkId))
+            {
+                return;
+            }
+
             if (rawChunkId == FACADE)
             {
                 r.Logger?.LogDebug("- FACADE -");
@@ -386,6 +391,11 @@ public partial class CMwNod : IClass
         {
             Write(rw);
         }
+    }
+
+    protected virtual bool OnRawChunkIdRead(uint rawChunkId)
+    {
+        return true;
     }
 
 #if NET8_0_OR_GREATER

--- a/Src/GBX.NET/Engines/TrackMania/CCtnMediaBlockUiTMSimpleEvtsDisplay.chunkl
+++ b/Src/GBX.NET/Engines/TrackMania/CCtnMediaBlockUiTMSimpleEvtsDisplay.chunkl
@@ -1,5 +1,5 @@
 CCtnMediaBlockUiTMSimpleEvtsDisplay 0x24092000
-- inherits: CGameCtnMediaBlock
+- inherits: CGameCtnMediaBlockUi
 
 0x000
 

--- a/Src/GBX.NET/GBX.NET.csproj
+++ b/Src/GBX.NET/GBX.NET.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <PackageId>GBX.NET</PackageId>
-        <VersionPrefix>2.4.0</VersionPrefix>
+        <VersionPrefix>2.4.1</VersionPrefix>
         <Authors>BigBang1112</Authors>
         <Description>General purpose library for Gbx files - data from Nadeo games like Trackmania or Shootmania. It supports high performance serialization and deserialization of 400+ Gbx classes.</Description>
         <Copyright>Copyright (c) 2026 Petr Pivoňka</Copyright>

--- a/Src/GBX.NET/Serialization/BoundedStream.cs
+++ b/Src/GBX.NET/Serialization/BoundedStream.cs
@@ -3,10 +3,10 @@
 internal sealed partial class BoundedStream : Stream
 {
     private readonly Stream baseStream;
-    private readonly long length;
-    private readonly long startPosition;
+    private readonly int length;
+    private readonly int startPosition;
 
-    private long remaining;
+    private int remaining;
     private MemoryStream? memoryStream;
 
     public override bool CanRead => true;
@@ -22,14 +22,14 @@ internal sealed partial class BoundedStream : Stream
 
     public long Remaining => remaining;
 
-    public BoundedStream(Stream baseStream, long length)
+    public BoundedStream(Stream baseStream, int length)
     {
         this.baseStream = baseStream ?? throw new ArgumentNullException(nameof(baseStream));
         if (!baseStream.CanRead) throw new ArgumentException("Base stream must be readable.");
         if (length < 0) throw new ArgumentOutOfRangeException(nameof(length));
 
         this.length = length;
-        startPosition = baseStream.CanSeek ? baseStream.Position : 0;
+        startPosition = baseStream.CanSeek ? (int)baseStream.Position : 0;
         remaining = length;
     }
 
@@ -173,7 +173,7 @@ internal sealed partial class BoundedStream : Stream
             memoryStream.Seek(newPosition, SeekOrigin.Begin);
         }
 
-        remaining = length - newPosition;
+        remaining = length - (int)newPosition;
         return newPosition;
     }
 

--- a/Src/GBX.NET/Serialization/Chunking/ChunkSetOfT.cs
+++ b/Src/GBX.NET/Serialization/Chunking/ChunkSetOfT.cs
@@ -26,6 +26,23 @@ public interface IChunkSet<TKind> : ICollection<TKind>, IEnumerable<TKind>, IEnu
     T Create<T>() where T : TKind, new();
 
     /// <summary>
+    /// Tries to create a new chunk using the ID. Returns false if the same chunk ID already exists.
+    /// </summary>
+    /// <param name="chunkId">ID of the chunk.</param>
+    /// <param name="preferHeaderChunks">Whether to prefer creating header chunks if available.</param>
+    /// <param name="chunk">The created chunk if successful.</param>
+    /// <returns>True if a new chunk was successfully created, otherwise false.</returns>
+    bool TryCreate(uint chunkId, bool preferHeaderChunks, out TKind chunk);
+
+    /// <summary>
+    /// Tries to create a new chunk using the chunk type. Returns false if the same chunk already exists.
+    /// </summary>
+    /// <typeparam name="T">Type of the chunk.</typeparam>
+    /// <param name="chunk">The created chunk if successful.</param>
+    /// <returns>True if a new chunk was successfully created, otherwise false.</returns>
+    bool TryCreate<T>(out T chunk) where T : TKind, new();
+
+    /// <summary>
     /// Gets a chunk using the ID.
     /// </summary>
     /// <param name="chunkId">ID of the chunk.</param>
@@ -163,6 +180,34 @@ internal class ChunkSet<TKind>(CMwNod? node) : IChunkSet<TKind> where TKind : IC
         Add(newChunk);
 
         return newChunk;
+    }
+
+    public bool TryCreate(uint chunkId, bool preferHeaderChunks, out TKind chunk)
+    {
+        if (chunksById.TryGetValue(chunkId, out chunk))
+        {
+            return false;
+        }
+
+        chunk = New(chunkId, preferHeaderChunks);
+
+        Add(chunk);
+
+        return true;
+    }
+
+    public bool TryCreate<T>(out T chunk) where T : TKind, new()
+    {
+        if (chunksByType.TryGetValue(typeof(T), out var chunkBase))
+        {
+            chunk = (T)chunkBase;
+            return false;
+        }
+
+        chunk = new T();
+        Add(chunk);
+
+        return true;
     }
 
     public TKind? Get(uint chunkId)

--- a/Tools/ParseRepeater/Properties/launchSettings.json
+++ b/Tools/ParseRepeater/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ParseRepeater": {
       "commandName": "Project",
-      "commandLineArgs": "\"D:\\GbxTools\\Dataset\\TM10\\Alpine\\Media\\Texture\\AlpineBark.Texture.gbx\""
+      "commandLineArgs": "\"E:\\Games\\TrackMania Nations ESWC\\GameData\\Tracks\\Replays\\Bench.Replay.Gbx\""
     }
   }
 }


### PR DESCRIPTION
- Fixed sample reading of TMF and older versions
- Added `TryCreateChunk`
- Implemented `CControlList` `0x007`
- Slightly reduced allocation size of `BoundedStream`
- Fixed `CCtnMediaBlockUiTMSimpleEvtsDisplay` to inherit `CGameCtnMediaBlockUi`