### PR TITLE
2.4.2

### DIFF
--- a/Generators/GBX.NET.Generators/SubGenerators/ClassDataSubGenerator.cs
+++ b/Generators/GBX.NET.Generators/SubGenerators/ClassDataSubGenerator.cs
@@ -378,7 +378,7 @@ internal class ClassDataSubGenerator
             return;
         }
 
-        sb.Append("    public static new uint Id => 0x");
+        sb.Append("    [Hexadecimal] public static new uint Id => 0x");
         sb.Append(id.ToString("X8"));
         sb.AppendLine(";");
     }

--- a/Src/GBX.NET/Components/GbxBody.cs
+++ b/Src/GBX.NET/Components/GbxBody.cs
@@ -38,9 +38,9 @@ public sealed partial class GbxBody
 
         var sb = new StringBuilder();
         sb.Append("GbxBody (compressed - ");
-        sb.Append(CompressedSize.Value.ToString("N0"));
+        sb.Append(ByteHelper.ToByteSize(CompressedSize.Value));
         sb.Append('/');
-        sb.Append(UncompressedSize.ToString("N0"));
+        sb.Append(ByteHelper.ToByteSize(UncompressedSize));
         sb.Append(" bytes");
 
         if (CompressionRatio.HasValue)

--- a/Src/GBX.NET/Engines/Game/CGameBuddy.cs
+++ b/Src/GBX.NET/Engines/Game/CGameBuddy.cs
@@ -1,0 +1,8 @@
+﻿namespace GBX.NET.Engines.Game;
+
+public partial class CGameBuddy
+{
+    private string? nickName;
+    [SupportsFormatting]
+    public string? NickName { get => nickName; set => nickName = value; }
+}

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.chunkl
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.chunkl
@@ -356,13 +356,13 @@ CGameCtnChallenge 0x03043000 // A map.
  version
  byte<PaletteColor> Palette
 
-0x3F001000 (skippable)
+0x3F001000 (skippable) [TMF]
 
-0x3F001001 (skippable)
+0x3F001001 (skippable) [TMF]
 
-0x3F001002 (skippable, base: 0x3F001001)
+0x3F001002 (skippable, base: 0x3F001001) [TMF]
 
-0x3F001003 (skippable, base: 0x3F001001)
+0x3F001003 (skippable, base: 0x3F001001) [TMF]
 
 archive BotPath
  int Clan

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.chunkl
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.chunkl
@@ -109,7 +109,7 @@ CGameCtnChallenge 0x03043000 // A map.
  int // code says DoBool, likely IsPlatform (Mode == 1), but maps yield something like 1698004
 
 0x017 (skippable) [TMS, TMO, TMSX, TMNESWC, TMU, TMF] // checkpoints
- int3[] Checkpoints
+ list<int3> Checkpoints
 
 0x018 (skippable) [TMS, TMO, TMSX, TMNESWC, TMU, TMF, MP3, TMT, MP4, TM2020] // laps
  bool IsLapRace

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -233,6 +233,13 @@ public partial class CGameCtnChallenge :
     [AppliedWithChunk<Chunk0304301F>]
     public Id? Collection => mapInfo?.Collection;
 
+    private Ident decoration = Ident.Empty;
+    [AppliedWithChunk<HeaderChunk03043003>]
+    [AppliedWithChunk<Chunk0304300F>]
+    [AppliedWithChunk<Chunk03043013>]
+    [AppliedWithChunk<Chunk0304301F>]
+    public Ident Decoration { get => decoration; set => decoration = value; }
+
     private List<CGameCtnBlock>? blocks;
     [AppliedWithChunk<Chunk0304300F>]
     [AppliedWithChunk<Chunk03043013>]

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -1323,7 +1323,9 @@ public partial class CGameCtnChallenge :
 
             if (Version < 6)
             {
-                if (n.ContainsChunk<Chunk3F001001>() || n.ContainsChunk<Chunk3F001002>() || n.ContainsChunk<Chunk3F001003>())
+                Chunk3F001001 tmUnlimiterChunk = n.GetChunk<Chunk3F001001>() ?? n.GetChunk<Chunk3F001002>() ?? n.GetChunk<Chunk3F001003>();
+
+                if (tmUnlimiterChunk?.Version > 0)
                 {
                     w.WriteListWritable(n.TMUnlimiterData?.FakeBlocks, version: Version);
                     return;

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -61,6 +61,12 @@ public partial class CGameCtnChallenge :
         }
     }
 
+    private string? authorNickname;
+    [SupportsFormatting]
+    [AppliedWithChunk<HeaderChunk03043008>]
+    [AppliedWithChunk<Chunk03043042>]
+    public string? AuthorNickname { get => authorNickname; set => authorNickname = value; }
+
     /// <summary>
     /// Time of the bronze medal. If <see cref="ChallengeParameters"/> is available, it uses the value from there instead.
     /// </summary>
@@ -459,6 +465,7 @@ public partial class CGameCtnChallenge :
     public float ThumbnailFarClipPlane { get => thumbnailFarClipPlane; set => thumbnailFarClipPlane = value; }
 
     private string? comments;
+    [SupportsFormatting]
     [AppliedWithChunk<Chunk03043028>]
     [AppliedWithChunk<Chunk0304302D>]
     [AppliedWithChunk<Chunk03043036>]

--- a/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnChallenge.cs
@@ -1323,7 +1323,7 @@ public partial class CGameCtnChallenge :
 
             if (Version < 6)
             {
-                Chunk3F001001 tmUnlimiterChunk = n.GetChunk<Chunk3F001001>() ?? n.GetChunk<Chunk3F001002>() ?? n.GetChunk<Chunk3F001003>();
+                var tmUnlimiterChunk = n.GetChunk<Chunk3F001001>() ?? (Chunk3F001001?)n.GetChunk<Chunk3F001002>() ?? (Chunk3F001001?)n.GetChunk<Chunk3F001003>();
 
                 if (tmUnlimiterChunk?.Version > 0)
                 {

--- a/Src/GBX.NET/Engines/Game/CGameCtnMediaClipGroup.cs
+++ b/Src/GBX.NET/Engines/Game/CGameCtnMediaClipGroup.cs
@@ -78,5 +78,11 @@ public partial class CGameCtnMediaClipGroup
     }
 
     [ArchiveGenerationOptions(StructureKind = StructureKind.SeparateReadAndWrite)]
-    public partial class Trigger;
+    public partial class Trigger
+    {
+        public override string ToString()
+        {
+            return $"Trigger: {Coords.Count} coords";
+        }
+    }
 }

--- a/Src/GBX.NET/Engines/Game/CGameGhost.Data.cs
+++ b/Src/GBX.NET/Engines/Game/CGameGhost.Data.cs
@@ -14,6 +14,7 @@ public partial class CGameGhost
         public TimeInt32 SamplePeriod { get; set; }
 
         public List<Sample> Samples { get; set; } = [];
+        [Hexadecimal]
         public uint SavedMobilClassId { get; set; }
         public bool IsFixedTimeStep { get; set; }
 

--- a/Src/GBX.NET/Engines/Game/CGameNetOnlineMessage.cs
+++ b/Src/GBX.NET/Engines/Game/CGameNetOnlineMessage.cs
@@ -1,0 +1,9 @@
+﻿namespace GBX.NET.Engines.Game;
+
+public partial class CGameNetOnlineMessage
+{
+    private string? message;
+    [AppliedWithChunk<Chunk03028000>]
+    [SupportsFormatting]
+    public string? Message { get => message; set => message = value; }
+}

--- a/Src/GBX.NET/Engines/Game/CGamePlayerProfile.cs
+++ b/Src/GBX.NET/Engines/Game/CGamePlayerProfile.cs
@@ -5,7 +5,13 @@ namespace GBX.NET.Engines.Game;
 public partial class CGamePlayerProfile
 {
     private string? description;
+    [SupportsFormatting]
     public string? Description { get => description; set => description = value; }
+
+    private string? nickName;
+    [SupportsFormatting]
+    [AppliedWithChunk<Chunk0308C05B>]
+    public string? NickName { get => nickName; set => nickName = value; }
 
     private UInt128 cryptedPassword;
     public UInt128 CryptedPassword { get => cryptedPassword; set => cryptedPassword = value; }

--- a/Src/GBX.NET/Engines/Game/CGamePlayerProfileChunk_AccountSettings.cs
+++ b/Src/GBX.NET/Engines/Game/CGamePlayerProfileChunk_AccountSettings.cs
@@ -2,6 +2,14 @@
 
 public partial class CGamePlayerProfileChunk_AccountSettings
 {
+    private string? nickName;
+    [SupportsFormatting]
+    public string? NickName { get => nickName; set => nickName = value; }
+
+    private string? description;
+    [SupportsFormatting]
+    public string? Description { get => description; set => description = value; }
+
     public bool LoginValidated
     {
         get => BitHelper.GetBit(flags, 0);

--- a/Src/GBX.NET/Engines/Hms/CHmsLightMapCache.SMapping.cs
+++ b/Src/GBX.NET/Engines/Hms/CHmsLightMapCache.SMapping.cs
@@ -389,7 +389,12 @@ public partial class CHmsLightMapCache
 
             // for write, it picks one of the decompressed arrays for count
             // during write, there should be a constraint that all decompressed arrays must have the same length
-            count = rw.Int32(zlibData2Decompressed1?.Length ?? 0);
+            if (rw.Writer is not null)
+            {
+                count = ZlibData1Decompressed?.Length ?? 0;
+            }
+
+            rw.Int32(ref count);
 
             if (version >= 1)
             {

--- a/Src/GBX.NET/GBX.NET.csproj
+++ b/Src/GBX.NET/GBX.NET.csproj
@@ -42,7 +42,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
         <PackageReference Include="System.IO.Hashing" Version="10.0.2" />
-        <PackageReference Include="TmEssentials" Version="2.6.2" />
+        <PackageReference Include="TmEssentials" Version="2.7.0" />
         <PackageReference Include="Zomp.SyncMethodGenerator" Version="2.0.7">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/GBX.NET/GBX.NET.csproj
+++ b/Src/GBX.NET/GBX.NET.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <PackageId>GBX.NET</PackageId>
-        <VersionPrefix>2.4.1</VersionPrefix>
+        <VersionPrefix>2.4.2</VersionPrefix>
         <Authors>BigBang1112</Authors>
         <Description>General purpose library for Gbx files - data from Nadeo games like Trackmania or Shootmania. It supports high performance serialization and deserialization of 400+ Gbx classes.</Description>
         <Copyright>Copyright (c) 2026 Petr Pivoňka</Copyright>

--- a/Src/GBX.NET/IClass.cs
+++ b/Src/GBX.NET/IClass.cs
@@ -11,6 +11,7 @@ public interface IClass
     /// <summary>
     /// ID of the class.
     /// </summary>
+    [Hexadecimal]
     static abstract uint Id { get; }
 #endif
 

--- a/Src/GBX.NET/Serialization/Chunking/Chunk.cs
+++ b/Src/GBX.NET/Serialization/Chunking/Chunk.cs
@@ -13,6 +13,7 @@ public interface IChunk
     /// <summary>
     /// ID of the chunk.
     /// </summary>
+    [Hexadecimal]
     uint Id { get; }
 
     bool Ignore { get; }
@@ -30,6 +31,7 @@ public interface IChunk
 public abstract class Chunk : IReadableWritableChunk
 {
     /// <inheritdoc />
+    [Hexadecimal]
     public abstract uint Id { get; }
 
     public virtual bool Ignore => false;

--- a/Src/GBX.NET/Serialization/Chunking/ChunkSetOfT.cs
+++ b/Src/GBX.NET/Serialization/Chunking/ChunkSetOfT.cs
@@ -6,7 +6,7 @@ namespace GBX.NET.Serialization.Chunking;
 /// <summary>
 /// A set of chunks.
 /// </summary>
-public interface IChunkSet<TKind> : ICollection<TKind>, IEnumerable<TKind>, ICollection, IEnumerable where TKind : IChunk
+public interface IChunkSet<TKind> : ICollection<TKind>, IEnumerable<TKind>, IEnumerable where TKind : IChunk
 {
     IComparer<TKind> Comparer { get; }
 
@@ -89,7 +89,7 @@ public interface IChunkSet<TKind> : ICollection<TKind>, IEnumerable<TKind>, ICol
     bool Contains<T>() where T : TKind;
 }
 
-internal class ChunkSet<TKind>(CMwNod? node) : IChunkSet<TKind> where TKind : IChunk
+internal class ChunkSet<TKind>(CMwNod? node) : IChunkSet<TKind>, ICollection where TKind : IChunk
 {
     private readonly CMwNod? node = node;
     private readonly List<TKind> chunks = [];

--- a/Src/GBX.NET/Serialization/Chunking/ChunkSetOfT.cs
+++ b/Src/GBX.NET/Serialization/Chunking/ChunkSetOfT.cs
@@ -6,7 +6,7 @@ namespace GBX.NET.Serialization.Chunking;
 /// <summary>
 /// A set of chunks.
 /// </summary>
-public interface IChunkSet<TKind> : ICollection<TKind>, IEnumerable<TKind>, IEnumerable where TKind : IChunk
+public interface IChunkSet<TKind> : ICollection<TKind>, IEnumerable<TKind>, ICollection, IEnumerable where TKind : IChunk
 {
     IComparer<TKind> Comparer { get; }
 
@@ -103,9 +103,14 @@ internal class ChunkSet<TKind>(CMwNod? node) : IChunkSet<TKind> where TKind : IC
 #else
     private readonly object _lock = new();
 #endif
+    private object? _syncRoot;
 
     public int Count => chunks.Count;
     public bool IsReadOnly => false;
+
+    bool ICollection.IsSynchronized => false;
+
+    object ICollection.SyncRoot => _syncRoot ??= new object();
 
     protected virtual TKind New(uint chunkId, bool preferHeaderChunks)
     {
@@ -184,8 +189,9 @@ internal class ChunkSet<TKind>(CMwNod? node) : IChunkSet<TKind> where TKind : IC
 
     public bool TryCreate(uint chunkId, bool preferHeaderChunks, out TKind chunk)
     {
-        if (chunksById.TryGetValue(chunkId, out chunk))
+        if (chunksById.TryGetValue(chunkId, out var chunkById) && chunkById is not null) 
         {
+            chunk = chunkById;
             return false;
         }
 
@@ -317,5 +323,10 @@ internal class ChunkSet<TKind>(CMwNod? node) : IChunkSet<TKind> where TKind : IC
     IEnumerator IEnumerable.GetEnumerator()
     {
         return GetEnumerator();
+    }
+
+    void ICollection.CopyTo(Array array, int index)
+    {
+        chunks.CopyTo((TKind[])array, index);
     }
 }

--- a/Src/GBX.NET/Serialization/Chunking/HeaderChunk.cs
+++ b/Src/GBX.NET/Serialization/Chunking/HeaderChunk.cs
@@ -27,6 +27,7 @@ public sealed class HeaderChunk(uint id) : IHeaderChunk
     /// <summary>
     /// ID of the header chunk.
     /// </summary>
+    [Hexadecimal]
     public uint Id => id;
 
     /// <inheritdoc />

--- a/Src/GBX.NET/Serialization/Chunking/HeaderChunkInfo.cs
+++ b/Src/GBX.NET/Serialization/Chunking/HeaderChunkInfo.cs
@@ -1,3 +1,3 @@
 ﻿namespace GBX.NET.Serialization.Chunking;
 
-internal readonly record struct HeaderChunkInfo(uint Id, int Size, bool IsHeavy);
+internal readonly record struct HeaderChunkInfo([property: Hexadecimal] uint Id, int Size, bool IsHeavy);

--- a/Src/GBX.NET/Serialization/Chunking/SkippableChunk.cs
+++ b/Src/GBX.NET/Serialization/Chunking/SkippableChunk.cs
@@ -4,6 +4,7 @@ namespace GBX.NET.Serialization.Chunking;
 
 public sealed class SkippableChunk(uint id) : ISkippableChunk
 {
+    [Hexadecimal]
     public uint Id => id;
 
     /// <inheritdoc />

--- a/Src/GBX.NET/Serialization/GbxHeaderReader.cs
+++ b/Src/GBX.NET/Serialization/GbxHeaderReader.cs
@@ -55,11 +55,6 @@ internal sealed class GbxHeaderReader(GbxReader reader)
             logger?.LogWarning("Number of nodes {NumNodes} exceeds 32767, which may cause the game to ignore the Gbx.", header.NumNodes);
         }
 
-        if (header.NumNodes > 1_000_000)
-        {
-            throw new InvalidDataException($"Number of nodes {header.NumNodes} is over 1 million, which is likely invalid. Maybe OpenPlanetHookExtractMode is on?");
-        }
-
         return header;
     }
 

--- a/Src/GBX.NET/Serialization/GbxHeaderReader.cs
+++ b/Src/GBX.NET/Serialization/GbxHeaderReader.cs
@@ -45,6 +45,21 @@ internal sealed class GbxHeaderReader(GbxReader reader)
         header.NumNodes = reader.ReadInt32();
         logger?.LogDebug("Number of nodes: {NumNodes}", header.NumNodes);
 
+        if (header.NumNodes < 0)
+        {
+            throw new InvalidDataException($"Number of nodes {header.NumNodes} is negative.");
+        }
+
+        if (header.NumNodes > short.MaxValue)
+        {
+            logger?.LogWarning("Number of nodes {NumNodes} exceeds 32767, which may cause the game to ignore the Gbx.", header.NumNodes);
+        }
+
+        if (header.NumNodes > 1_000_000)
+        {
+            throw new InvalidDataException($"Number of nodes {header.NumNodes} is over 1 million, which is likely invalid.");
+        }
+
         return header;
     }
 

--- a/Src/GBX.NET/Serialization/GbxHeaderReader.cs
+++ b/Src/GBX.NET/Serialization/GbxHeaderReader.cs
@@ -57,7 +57,7 @@ internal sealed class GbxHeaderReader(GbxReader reader)
 
         if (header.NumNodes > 1_000_000)
         {
-            throw new InvalidDataException($"Number of nodes {header.NumNodes} is over 1 million, which is likely invalid.");
+            throw new InvalidDataException($"Number of nodes {header.NumNodes} is over 1 million, which is likely invalid. Maybe OpenPlanetHookExtractMode is on?");
         }
 
         return header;

--- a/Src/GBX.NET/Serialization/GbxRefTableReader.cs
+++ b/Src/GBX.NET/Serialization/GbxRefTableReader.cs
@@ -20,6 +20,16 @@ internal sealed class GbxRefTableReader(GbxReader reader, GbxHeader header, stri
             return null;
         }
 
+        if (numExternalNodes < 0)
+        {
+            throw new InvalidDataException($"Number of external nodes is negative ({header.NumNodes}).");
+        }
+
+        if (numExternalNodes > 1_000_000)
+        {
+            throw new InvalidDataException($"Number of external nodes is way too many ({header.NumNodes}). Maybe OpenPlanetHookExtractMode is on?");
+        }
+
         using var _ = logger?.BeginScope("RefTable");
 
         var refTable = new GbxRefTable

--- a/Src/GBX.NET/Serialization/GbxRefTableReader.cs
+++ b/Src/GBX.NET/Serialization/GbxRefTableReader.cs
@@ -22,12 +22,12 @@ internal sealed class GbxRefTableReader(GbxReader reader, GbxHeader header, stri
 
         if (numExternalNodes < 0)
         {
-            throw new InvalidDataException($"Number of external nodes is negative ({header.NumNodes}).");
+            throw new InvalidDataException($"Number of external nodes is negative ({numExternalNodes}).");
         }
 
         if (numExternalNodes > 1_000_000)
         {
-            throw new InvalidDataException($"Number of external nodes is way too many ({header.NumNodes}). Maybe OpenPlanetHookExtractMode is on?");
+            throw new InvalidDataException($"Number of external nodes is way too many ({numExternalNodes}). Maybe OpenPlanetHookExtractMode is on?");
         }
 
         using var _ = logger?.BeginScope("RefTable");


### PR DESCRIPTION
- Fixed write of LightmapCache when discovered
- Fixed TMUnlimiter write in vanilla mode
- Improved various `ToString`s
- Added checks for the number of nodes
- Added more attributes to various properties
- `CGameCtnChallenge.Checkpoints` is now `List`