### PR TITLE
CHmsLightMapMood implementation

### DIFF
--- a/Src/GBX.NET/Engines/Hms/CHmsLightMapMood.chunkl
+++ b/Src/GBX.NET/Engines/Hms/CHmsLightMapMood.chunkl
@@ -1,1 +1,8 @@
 CHmsLightMapMood 0x06023000
+
+0x000
+ float
+ float
+ float
+ float
+ float


### PR DESCRIPTION
Added additional float parameters to CHmsLightMapMood.

In TMUF, it has only one known chunk. These parameters are most likely related to lightmap intensity, weighting, scaling, or bias. Default values are:

2.0
2.0
0.4
1.0
0.5